### PR TITLE
fix FileNotFoundError when loading colmap sparse model

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -154,9 +154,9 @@ def readColmapSceneInfo(path, images, eval, llffhold=8):
 
     nerf_normalization = getNerfppNorm(train_cam_infos)
 
-    ply_path = os.path.join(path, "sparse/0/points3d.ply")
-    bin_path = os.path.join(path, "sparse/0/points3d.bin")
-    txt_path = os.path.join(path, "sparse/0/points3d.txt")
+    ply_path = os.path.join(path, "sparse/0/points3D.ply")
+    bin_path = os.path.join(path, "sparse/0/points3D.bin")
+    txt_path = os.path.join(path, "sparse/0/points3D.txt")
     if not os.path.exists(ply_path):
         print("Converting point3d.bin to .ply, will happen only the first time you open the scene.")
         try:


### PR DESCRIPTION
Hi, the colmap sparse model uses upper-case `3D` rather than `3d` as filename [(scripts/python/read_write_model.py#L437)](https://github.com/colmap/colmap/blob/2f41a507d7a7df7810ebe56d1e2999d5bd8023fc/scripts/python/read_write_model.py#L437).
All the scenes provided on your project page are using `points3D.bin`:
![image](https://github.com/graphdeco-inria/gaussian-splatting/assets/564361/3965af67-9db1-484d-8040-437f18bb9fb1)


This pull request will fix FileNotFoundError when loading colmap sparse model.