### PR TITLE
Added forward pass for depth rendering

### DIFF
--- a/gaussian_renderer/__init__.py
+++ b/gaussian_renderer/__init__.py
@@ -81,7 +81,7 @@ def render(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tensor, 
         colors_precomp = override_color
 
     # Rasterize visible Gaussians to image, obtain their radii (on screen). 
-    rendered_image, radii = rasterizer(
+    rendered_image, radii, depth = rasterizer(
         means3D = means3D,
         means2D = means2D,
         shs = shs,
@@ -95,5 +95,6 @@ def render(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tensor, 
     # They will be excluded from value updates used in the splitting criteria.
     return {"render": rendered_image,
             "viewspace_points": screenspace_points,
-            "visibility_filter" : radii > 0,
-            "radii": radii}
+            "visibility_filter": radii > 0,
+            "radii": radii,
+           "depth": depth}


### PR DESCRIPTION
Here are small changes required in this repo to align with the actual changes done in a PR in the renderer repo.

See here:
https://github.com/graphdeco-inria/diff-gaussian-rasterization/pull/2