### PR TITLE
Update .gitmodules to include .git for SIBR_viewers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/graphdeco-inria/diff-gaussian-rasterization
 [submodule "SIBR_viewers"]
 	path = SIBR_viewers
-	url = https://gitlab.inria.fr/sibr/sibr_core
+	url = https://gitlab.inria.fr/sibr/sibr_core.git


### PR DESCRIPTION
Hi, thanks for the great work!

One small issue: cloning fails with the following error on Linux:

```
Cloning into 'gaussian-splatting'...
remote: Enumerating objects: 656, done.
remote: Counting objects: 100% (249/249), done.
remote: Compressing objects: 100% (64/64), done.
remote: Total 656 (delta 206), reused 199 (delta 185), pack-reused 407
Receiving objects: 100% (656/656), 2.11 MiB | 0 bytes/s, done.
Resolving deltas: 100% (384/384), done.
Submodule 'SIBR_viewers' (https://gitlab.inria.fr/sibr/sibr_core) registered for path 'SIBR_viewers'
Submodule 'submodules/diff-gaussian-rasterization' (https://github.com/graphdeco-inria/diff-gaussian-rasterization) registered for path 'submodules/diff-gaussian-rasterization'
Submodule 'submodules/simple-knn' (https://gitlab.inria.fr/bkerbl/simple-knn.git) registered for path 'submodules/simple-knn'
Cloning into 'SIBR_viewers'...
error: RPC failed; result=22, HTTP code = 422
fatal: The remote end hung up unexpectedly
Clone of 'https://gitlab.inria.fr/sibr/sibr_core' into submodule path 'SIBR_viewers' failed
```

Adding .git extension to SIBR_viewers solves the issue.
