### PR TITLE
fix bug for mask loading

### DIFF
--- a/utils/camera_utils.py
+++ b/utils/camera_utils.py
@@ -43,7 +43,7 @@ def loadCam(args, id, cam_info, resolution_scale):
     gt_image = resized_image_rgb[:3, ...]
     loaded_mask = None
 
-    if resized_image_rgb.shape[1] == 4:
+    if resized_image_rgb.shape[0] == 4:
         loaded_mask = resized_image_rgb[3:4, ...]
 
     return Camera(colmap_id=cam_info.uid, R=cam_info.R, T=cam_info.T, 


### PR DESCRIPTION
Hi,
 I have identified an issue related to the condition for loading the mask. Since the dimension 0 of the arraay "resized_image_rgb" is for RGBA channels, we should use index 0 instead of index 1.