### PR TITLE
allow for subfolders in images dir

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -94,7 +94,7 @@ def readColmapCameras(cam_extrinsics, cam_intrinsics, images_folder):
         else:
             assert False, "Colmap camera model not handled: only undistorted datasets (PINHOLE or SIMPLE_PINHOLE cameras) supported!"
 
-        image_path = os.path.join(images_folder, os.path.basename(extr.name))
+        image_path = os.path.join(images_folder, extr.name)
         image_name = os.path.basename(image_path).split(".")[0]
         image = Image.open(image_path)
 


### PR DESCRIPTION
When converting the images in COLMAP with a series of subdirs (you can fill 'input' with multiple folders to stitch together images from different cameras into 1 point cloud), train.py errors when trying to read the images as it assumes all images are at the root of the 'images' folder. This change uses the relative image path (which starts at the 'images' folder, so the path will be 'subfolder/image1.jpg') saved in the images.bin file.