### PR TITLE
Avoid wrong path for windows user

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -131,13 +131,13 @@ def storePly(path, xyz, rgb):
 
 def readColmapSceneInfo(path, images, eval, llffhold=8):
     try:
-        cameras_extrinsic_file = os.path.join(path, "sparse/0", "images.bin")
-        cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.bin")
+        cameras_extrinsic_file = os.path.join(path, "sparse", "0", "images.bin")
+        cameras_intrinsic_file = os.path.join(path, "sparse", "0", "cameras.bin")
         cam_extrinsics = read_extrinsics_binary(cameras_extrinsic_file)
         cam_intrinsics = read_intrinsics_binary(cameras_intrinsic_file)
     except:
-        cameras_extrinsic_file = os.path.join(path, "sparse/0", "images.txt")
-        cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.txt")
+        cameras_extrinsic_file = os.path.join(path, "sparse", "0", "images.txt")
+        cameras_intrinsic_file = os.path.join(path, "sparse", "0", "cameras.txt")
         cam_extrinsics = read_extrinsics_text(cameras_extrinsic_file)
         cam_intrinsics = read_intrinsics_text(cameras_intrinsic_file)
 
@@ -154,9 +154,9 @@ def readColmapSceneInfo(path, images, eval, llffhold=8):
 
     nerf_normalization = getNerfppNorm(train_cam_infos)
 
-    ply_path = os.path.join(path, "sparse/0/points3D.ply")
-    bin_path = os.path.join(path, "sparse/0/points3D.bin")
-    txt_path = os.path.join(path, "sparse/0/points3D.txt")
+    ply_path = os.path.join(path, "sparse", "0", "points3D.ply")
+    bin_path = os.path.join(path, "sparse", "0", "points3D.bin")
+    txt_path = os.path.join(path, "sparse", "0", "points3D.txt")
     if not os.path.exists(ply_path):
         print("Converting point3d.bin to .ply, will happen only the first time you open the scene.")
         try:


### PR DESCRIPTION
Avoid " No such file or directory" error on Windows, sometime the path look like ``\\sparse/0\\`` witch isn't recognized.