### PR TITLE
Add simple custom offline renderer to render.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,19 @@ python metrics.py -m <path to pre-trained model>
   #### --convert_cov3D_python
   Flag to make pipeline render with computed 3D covariance from PyTorch instead of ours.
 
+  **The below parameters are used for rendering a custom trajectory**
+  #### --camera_trajectory
+  Path to the trajectory file, a torch tensor in shape [N, 4, 4]
+  #### --camera_parameters
+  width, height, and focal length of rendering as specified, example like "976,544,581.743" (comma separated, no space between)
+
 </details>
+
+Additionally, `render.py` also allows to render a custom trajectory with a simple camera pinhole (by optionally specifying width, height, and focal):
+```shell
+python render.py -m <path to pre-trained model> -s <path to colmap dataset> --camera_trajectory path.pt --camera_parameters 1080,960,1000
+```
+where `path.pt` is a `[N, 4, 4]` torch tensor, each 4x4 matrix is the transform from camera to world created via `torch.save(path, "path.pt")`.
 
 <details>
 <summary><span style="font-weight: bold;">Command Line Arguments for metrics.py</span></summary>

--- a/render.py
+++ b/render.py
@@ -21,6 +21,13 @@ from argparse import ArgumentParser
 from arguments import ModelParams, PipelineParams, get_combined_args
 from gaussian_renderer import GaussianModel
 
+from PIL import Image
+from scene.dataset_readers import CameraInfo
+from utils.graphics_utils import focal2fov, fov2focal
+from utils.camera_utils import cameraList_from_camInfos
+import numpy as np
+from typing import List
+
 def render_set(model_path, name, iteration, views, gaussians, pipeline, background):
     render_path = os.path.join(model_path, name, "ours_{}".format(iteration), "renders")
     gts_path = os.path.join(model_path, name, "ours_{}".format(iteration), "gt")
@@ -34,7 +41,17 @@ def render_set(model_path, name, iteration, views, gaussians, pipeline, backgrou
         torchvision.utils.save_image(rendering, os.path.join(render_path, '{0:05d}'.format(idx) + ".png"))
         torchvision.utils.save_image(gt, os.path.join(gts_path, '{0:05d}'.format(idx) + ".png"))
 
-def render_sets(dataset : ModelParams, iteration : int, pipeline : PipelineParams, skip_train : bool, skip_test : bool):
+def render_set_no_gt(model_path, name, iteration, views, gaussians, pipeline, background):
+    render_path = os.path.join(model_path, name, "ours_{}".format(iteration), "renders")
+
+    makedirs(render_path, exist_ok=True)
+
+    for idx, view in enumerate(tqdm(views, desc="Rendering progress")):
+        rendering = render(view, gaussians, pipeline, background)["render"]
+        torchvision.utils.save_image(rendering, os.path.join(render_path, '{0:05d}'.format(idx) + ".png"))
+
+def render_sets(dataset : ModelParams, iteration : int, pipeline : PipelineParams, skip_train : bool, skip_test : bool,
+                custom_cameras: List[CameraInfo]):
     with torch.no_grad():
         gaussians = GaussianModel(dataset.sh_degree)
         scene = Scene(dataset, gaussians, load_iteration=iteration, shuffle=False)
@@ -43,10 +60,34 @@ def render_sets(dataset : ModelParams, iteration : int, pipeline : PipelineParam
         background = torch.tensor(bg_color, dtype=torch.float32, device="cuda")
 
         if not skip_train:
-             render_set(dataset.model_path, "train", scene.loaded_iter, scene.getTrainCameras(), gaussians, pipeline, background)
+            render_set(dataset.model_path, "train", scene.loaded_iter, scene.getTrainCameras(), gaussians, pipeline, background)
 
         if not skip_test:
-             render_set(dataset.model_path, "test", scene.loaded_iter, scene.getTestCameras(), gaussians, pipeline, background)
+            render_set(dataset.model_path, "test", scene.loaded_iter, scene.getTestCameras(), gaussians, pipeline, background)
+
+        if custom_cameras:
+            render_set_no_gt(dataset.model_path, "custom", scene.loaded_iter, custom_cameras, gaussians, pipeline, background)
+
+def get_cam_infos(trajectory: torch.Tensor,
+                  input_width: int, input_height: int, input_focal_length: float):
+    cam_infos: List[CameraInfo] = []
+    for i in range(trajectory.shape[0]):
+        transform = np.linalg.inv(trajectory[i, :, :].numpy())
+        width = input_width
+        height = input_height
+        focal_length = input_focal_length
+        FovX = focal2fov(focal_length, width)
+        FovY = focal2fov(focal_length, height)
+
+        # create a dummy gt image with all pixels being zero
+        cam_info = CameraInfo(uid=0,
+                              R=np.transpose(transform[:3, :3]), T=transform[:3, 3],
+                              FovX=FovX, FovY=FovY, width=width, height=height,
+                              image=Image.fromarray(np.zeros((height, width, 3), dtype=np.byte), "RGB"),
+                              image_path="", image_name=f"frame_{i:03}")
+
+        cam_infos.append(cam_info)
+    return cam_infos
 
 if __name__ == "__main__":
     # Set up command line argument parser
@@ -57,10 +98,25 @@ if __name__ == "__main__":
     parser.add_argument("--skip_train", action="store_true")
     parser.add_argument("--skip_test", action="store_true")
     parser.add_argument("--quiet", action="store_true")
+    parser.add_argument("--camera_trajectory", type=str, default="", help="A camera trajectory file saved as torch.save(), in shape [N, 4, 4]")
+    parser.add_argument("--camera_parameters", type=str, default="976,544,581.743", help="width,height,focal: a comma separated list of numbers")
     args = get_combined_args(parser)
     print("Rendering " + args.model_path)
+
+    # Enable custom trajectory rendering will disable train/test renders
+    custom_cameras = []
+    if args.camera_trajectory:
+        args.skip_test = True
+        args.skip_train = True
+        width, height, focal = args.camera_parameters.split(",")
+        width = int(width)
+        height = int(height)
+        focal = float(focal)
+        camera_info = get_cam_infos(torch.load(args.camera_trajectory), width, height, focal)
+        custom_cameras = cameraList_from_camInfos(camera_info, 1.0, args)
+
 
     # Initialize system state (RNG)
     safe_state(args.quiet)
 
-    render_sets(model.extract(args), args.iteration, pipeline.extract(args), args.skip_train, args.skip_test)
+    render_sets(model.extract(args), args.iteration, pipeline.extract(args), args.skip_train, args.skip_test, custom_cameras)

--- a/utils/camera_utils.py
+++ b/utils/camera_utils.py
@@ -23,13 +23,13 @@ def loadCam(args, id, cam_info, resolution_scale):
         resolution = round(orig_w/(resolution_scale * args.resolution)), round(orig_h/(resolution_scale * args.resolution))
     else:  # should be a type that converts to float
         if args.resolution == -1:
-            if orig_w > 1600:
+            if orig_w > 1600 or orig_h > 1600:
                 global WARNED
                 if not WARNED:
-                    print("[ INFO ] Encountered quite large input images (>1.6K pixels width), rescaling to 1.6K.\n "
+                    print("[ INFO ] Encountered quite large input images (>1.6K pixels width or height), rescaling to 1.6K.\n "
                         "If this is not desired, please explicitly specify '--resolution/-r' as 1")
                     WARNED = True
-                global_down = orig_w / 1600
+                global_down = max(orig_w, orig_h) / 1600
             else:
                 global_down = 1
         else:


### PR DESCRIPTION
Hello,

I was looking for a simple python offline renderer (without SIBR based utilities) that can produce images at arbitrary camera path. I ended up customizing render.py. So here is the pull request for that.

Example:
```shell
python render.py -m <path to pre-trained model> -s <path to colmap dataset> \
 --camera_trajectory path.pt --camera_parameters 1080,960,1000
```

