### PR TITLE
Add docker scripts to gaussian-splatting

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,5 +67,5 @@ WORKDIR /home/${user_name}/
 
 
 RUN git config --global http.sslverify false
-RUN cd /home/${user_name}/workspace && git clone --recursive https://github.com/graphdeco-inria/gaussian-splatting && cd gaussian-splatting && ./docker/initialize.sh
+RUN cd /home/${user_name}/workspace && git clone --recursive https://github.com/graphdeco-inria/gaussian-splatting && cd gaussian-splatting && docker/initialize.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,6 @@ RUN \
 			sudo \
 			wget \
 			nano \
-            python3.8-venv \
             libboost-program-options-dev \
             libboost-filesystem-dev \
             libboost-graph-dev \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM tensorflow/tensorflow:latest-gpu
+#FROM tensorflow/tensorflow:latest-gpu
+FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
 
 ARG user_id
 ARG root_psw="12345678"
@@ -9,7 +10,7 @@ ARG user_name=user
 RUN \
 	echo "**** packages installation ****" \
 		&& apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub \
-		&& apt-get update && apt-get install -y \
+		&& apt-get update && apt-get dist-upgrade -y && apt-get install -y \
 			vim \
             build-essential \
             cmake \
@@ -48,6 +49,10 @@ RUN \
             libflann-dev \
             libatlas-base-dev \
             libsuitesparse-dev \
+            libcufft10 \
+            libcusparse11 \
+            libcublas11 \
+            libcublaslt11 \
 	&& echo "**** python pip update ****" \
 		&& /usr/bin/python3 -m pip install --upgrade pip \
 	&& echo "**** aliases for l and ll commands creation ****" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,8 @@ RUN \
 			vim \
             build-essential \
             cmake \
+            ffmpeg \
+            freeglut3-dev \
             libopencv-dev \
             libjpeg-dev \
             libpng-dev \
@@ -20,6 +22,8 @@ RUN \
             libpthread-stubs0-dev \
 			git \
 			virtualenv \
+            sqlite3 \
+            libsqlite3-dev \
 			time \
 			sudo \
 			wget \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,5 +67,5 @@ WORKDIR /home/${user_name}/
 
 
 RUN git config --global http.sslverify false
-RUN cd /home/${user_name}/workspace && git clone --recursive https://github.com/graphdeco-inria/gaussian-splatting && cd gaussian-splatting && docker/initialize.sh
+RUN cd /home/${user_name}/workspace && git clone --recursive https://github.com/graphdeco-inria/gaussian-splatting && cd gaussian-splatting # && docker/initialize.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,75 @@
+FROM tensorflow/tensorflow:latest-gpu
+
+ARG user_id
+ARG root_psw="12345678"
+ARG user_psw="ok"
+ARG user_name=user
+
+# Installs the necessary pkgs.
+RUN \
+	echo "**** packages installation ****" \
+		&& apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub \
+		&& apt-get update && apt-get install -y \
+			vim \
+            build-essential \
+            cmake \
+            libopencv-dev \
+            libjpeg-dev \
+            libpng-dev \
+            libglew-dev \
+            libpthread-stubs0-dev \
+			git \
+			virtualenv \
+			time \
+			sudo \
+			wget \
+			nano \
+            python3.8-venv \
+            libboost-program-options-dev \
+            libboost-filesystem-dev \
+            libboost-graph-dev \
+            libboost-regex-dev \
+            libboost-system-dev \
+            libboost-test-dev \
+            libeigen3-dev \
+            libsuitesparse-dev \
+            libfreeimage-dev \
+            libgoogle-glog-dev \
+            libgflags-dev \
+            libglew-dev \
+            qtbase5-dev \
+            libqt5opengl5-dev \
+            libcgal-dev \
+            libcgal-qt5-dev \
+            libmetis-dev \
+            libflann-dev \
+            libatlas-base-dev \
+            libsuitesparse-dev \
+	&& echo "**** python pip update ****" \
+		&& /usr/bin/python3 -m pip install --upgrade pip \
+	&& echo "**** aliases for l and ll commands creation ****" \
+		&& echo -e 'ls --color=auto "$@"' > /usr/bin/l \
+		&& echo -e 'ls -lah --color=auto "$@"' > /usr/bin/ll \
+    	&& chmod +x /usr/bin/ll /usr/bin/l \
+	&& echo "**** history-search-backward by pressing F8 ****" \
+		&& sed -i 's/# "\\e\[5~": history-search-backward/"\\e\[19~": history-search-backward/' /etc/inputrc \
+	&& echo "**** root password creation ****" \
+		&& echo "root:${root_psw}" | chpasswd \
+	&& echo "**** user creation ****" \
+		&& useradd -m -s /usr/bin/bash -u ${user_id} -G sudo ${user_name} \
+		&& echo "${user_name}:${user_psw}" | chpasswd \
+		&& chown -R ${user_name}:${user_name} /home/${user_name}/ \
+		&& mkdir /home/${user_name}/workspace/ \
+        && chown -R user:user /home/${user_name}/workspace
+
+
+USER ${user_name} 
+WORKDIR /home/${user_name}/
+ 
+
+#Read/Write: git clone ssh://ics\\ammarkov@cvrlcode.ics.forth.gr:29418/users/ammarkov/ammarkov.git
+#Read only: git clone https://ics\\ammarkov@cvrlcode.ics.forth.gr:8443/r/users/ammarkov/ammarkov.git
+
+RUN git config --global http.sslverify false
+RUN cd /home/${user_name}/workspace && git clone --recursive https://github.com/graphdeco-inria/gaussian-splatting && cd gaussian-splatting && ./docker/initialize.sh
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 #FROM tensorflow/tensorflow:latest-gpu
 FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
 
+ENV DEBIAN_FRONTEND noninteractive
+
 ARG user_id
 ARG root_psw="12345678"
 ARG user_psw="ok"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,10 +65,7 @@ RUN \
 
 USER ${user_name} 
 WORKDIR /home/${user_name}/
- 
 
-#Read/Write: git clone ssh://ics\\ammarkov@cvrlcode.ics.forth.gr:29418/users/ammarkov/ammarkov.git
-#Read only: git clone https://ics\\ammarkov@cvrlcode.ics.forth.gr:8443/r/users/ammarkov/ammarkov.git
 
 RUN git config --global http.sslverify false
 RUN cd /home/${user_name}/workspace && git clone --recursive https://github.com/graphdeco-inria/gaussian-splatting && cd gaussian-splatting && ./docker/initialize.sh

--- a/docker/build_and_deploy.sh
+++ b/docker/build_and_deploy.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# This script builds and runs a docker image for local use.
+
+#Although I dislike the use of docker for a myriad of reasons, due needing it to deploy on a particular machine
+#I am adding a docker container builder for the repository to automate the process
+
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR"
+cd ..
+REPOSITORY=`pwd`
+
+cd "$DIR"
+
+NAME="mocapnet"
+dockerfile_pth="$DIR"
+mount_pth="$REPOSITORY"
+
+# update tensorflow image
+docker pull tensorflow/tensorflow:latest-gpu
+
+# build and run tensorflow
+docker build \
+	-t $NAME \
+	$dockerfile_pth \
+	--build-arg user_id=$UID
+
+docker run -d \
+	--gpus all \
+	--shm-size 8G \
+	-it \
+	--name $NAME-container \
+	-v $mount_pth:/home/user/workspace \
+	$NAME
+
+
+docker ps -a
+
+OUR_DOCKER_ID=`docker ps -a | grep mocapnet | cut -f1 -d' '`
+echo "Our docker ID is : $OUR_DOCKER_ID"
+echo "Attaching it using : docker attach $OUD_DOCKER_ID"
+docker attach $OUR_DOCKER_ID
+
+exit 0

--- a/docker/build_and_deploy.sh
+++ b/docker/build_and_deploy.sh
@@ -12,7 +12,7 @@ REPOSITORY=`pwd`
 
 cd "$DIR"
 
-NAME="mocapnet"
+NAME="gaussian-splatting"
 dockerfile_pth="$DIR"
 mount_pth="$REPOSITORY"
 
@@ -36,7 +36,7 @@ docker run -d \
 
 docker ps -a
 
-OUR_DOCKER_ID=`docker ps -a | grep mocapnet | cut -f1 -d' '`
+OUR_DOCKER_ID=`docker ps -a | grep gaussian-splatting | cut -f1 -d' '`
 echo "Our docker ID is : $OUR_DOCKER_ID"
 echo "Attaching it using : docker attach $OUD_DOCKER_ID"
 docker attach $OUR_DOCKER_ID

--- a/docker/initialize.sh
+++ b/docker/initialize.sh
@@ -10,7 +10,7 @@ cd ceres-solver
 git checkout $(git describe --tags) # Checkout the latest release
 mkdir build
 cd build
-cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_CUDA_ARCHITECTURES=native #-DUSE_CUDA=OFF 
+cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_CUDA_ARCHITECTURES=60;70;80 #-DUSE_CUDA=OFF 
 
 
 make
@@ -24,7 +24,7 @@ cd colmap
 git checkout dev
 mkdir build
 cd build
-cmake .. -DCMAKE_CUDA_ARCHITECTURES=native #-DCUDA_ENABLED=OFF 
+cmake .. -DCMAKE_CUDA_ARCHITECTURES=60;70;80 #-DCUDA_ENABLED=OFF 
 make
 sudo make install
 CC=/usr/bin/gcc-6 CXX=/usr/bin/g++-6 cmake ..

--- a/docker/initialize.sh
+++ b/docker/initialize.sh
@@ -10,7 +10,7 @@ cd ceres-solver
 git checkout $(git describe --tags) # Checkout the latest release
 mkdir build
 cd build
-cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DUSE_CUDA=OFF #-DCMAKE_CUDA_ARCHITECTURES=native
+cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_CUDA_ARCHITECTURES=native #-DUSE_CUDA=OFF 
 
 
 make
@@ -24,7 +24,7 @@ cd colmap
 git checkout dev
 mkdir build
 cd build
-cmake .. -DCMAKE_CUDA_ARCHITECTURES=native -DCUDA_ENABLED=OFF 
+cmake .. -DCMAKE_CUDA_ARCHITECTURES=native #-DCUDA_ENABLED=OFF 
 make
 sudo make install
 CC=/usr/bin/gcc-6 CXX=/usr/bin/g++-6 cmake ..

--- a/docker/initialize.sh
+++ b/docker/initialize.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
 
+#git clone https://github.com/NVIDIA/cuda-samples
+#cd cuda-samples
+
+
 git clone https://ceres-solver.googlesource.com/ceres-solver
 cd ceres-solver
 git checkout $(git describe --tags) # Checkout the latest release
 mkdir build
 cd build
-cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_CUDA_ARCHITECTURES=native
+cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DUSE_CUDA=OFF #-DCMAKE_CUDA_ARCHITECTURES=native
 make
 sudo make install
 cd ..
@@ -18,7 +22,7 @@ cd colmap
 git checkout dev
 mkdir build
 cd build
-cmake .. -DCMAKE_CUDA_ARCHITECTURES=native
+cmake .. -DCMAKE_CUDA_ARCHITECTURES=native -DCUDA_ENABLED=OFF 
 make
 sudo make install
 CC=/usr/bin/gcc-6 CXX=/usr/bin/g++-6 cmake ..
@@ -28,7 +32,7 @@ cd ..
 
 pip install -q plyfile 
 
-pip install -q https://huggingface.co/camenduru/gaussian-splatting/resolve/main/diff_gaussian_rasterization-0.0.0-cp310-cp310-linux_x86_64.whl
-pip install -q https://huggingface.co/camenduru/gaussian-splatting/resolve/main/simple_knn-0.0.0-cp310-cp310-linux_x86_64.whl
+python3.10 -m pip install -q https://huggingface.co/camenduru/gaussian-splatting/resolve/main/diff_gaussian_rasterization-0.0.0-cp310-cp310-linux_x86_64.whl
+python3.10 -m pip install -q https://huggingface.co/camenduru/gaussian-splatting/resolve/main/simple_knn-0.0.0-cp310-cp310-linux_x86_64.whl
 
 exit 0

--- a/docker/initialize.sh
+++ b/docker/initialize.sh
@@ -11,6 +11,8 @@ git checkout $(git describe --tags) # Checkout the latest release
 mkdir build
 cd build
 cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DUSE_CUDA=OFF #-DCMAKE_CUDA_ARCHITECTURES=native
+
+
 make
 sudo make install
 cd ..

--- a/docker/initialize.sh
+++ b/docker/initialize.sh
@@ -10,7 +10,7 @@ cd ceres-solver
 git checkout $(git describe --tags) # Checkout the latest release
 mkdir build
 cd build
-cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_CUDA_ARCHITECTURES=60;70;80 #-DUSE_CUDA=OFF 
+cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_CUDA_ARCHITECTURES="60;70;80" #-DUSE_CUDA=OFF 
 
 
 make
@@ -24,10 +24,10 @@ cd colmap
 git checkout dev
 mkdir build
 cd build
-cmake .. -DCMAKE_CUDA_ARCHITECTURES=60;70;80 #-DCUDA_ENABLED=OFF 
+cmake .. -DCMAKE_CUDA_ARCHITECTURES="60;70;80" #-DCUDA_ENABLED=OFF 
 make
 sudo make install
-CC=/usr/bin/gcc-6 CXX=/usr/bin/g++-6 cmake ..
+#CC=/usr/bin/gcc-6 CXX=/usr/bin/g++-6 cmake ..
 cd ..
 cd ..
 
@@ -36,5 +36,8 @@ pip install -q plyfile
 
 python3.10 -m pip install -q https://huggingface.co/camenduru/gaussian-splatting/resolve/main/diff_gaussian_rasterization-0.0.0-cp310-cp310-linux_x86_64.whl
 python3.10 -m pip install -q https://huggingface.co/camenduru/gaussian-splatting/resolve/main/simple_knn-0.0.0-cp310-cp310-linux_x86_64.whl
+
+
+ln -s docker/run.sh ./run.sh
 
 exit 0

--- a/docker/initialize.sh
+++ b/docker/initialize.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+
+git clone https://ceres-solver.googlesource.com/ceres-solver
+cd ceres-solver
+git checkout $(git describe --tags) # Checkout the latest release
+mkdir build
+cd build
+cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_CUDA_ARCHITECTURES=native
+make
+sudo make install
+cd ..
+cd ..
+
+
+git clone https://github.com/colmap/colmap
+cd colmap
+git checkout dev
+mkdir build
+cd build
+cmake .. -DCMAKE_CUDA_ARCHITECTURES=native
+make
+sudo make install
+CC=/usr/bin/gcc-6 CXX=/usr/bin/g++-6 cmake ..
+cd ..
+cd ..
+
+
+pip install -q plyfile 
+
+pip install -q https://huggingface.co/camenduru/gaussian-splatting/resolve/main/diff_gaussian_rasterization-0.0.0-cp310-cp310-linux_x86_64.whl
+pip install -q https://huggingface.co/camenduru/gaussian-splatting/resolve/main/simple_knn-0.0.0-cp310-cp310-linux_x86_64.whl
+
+exit 0

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -9,7 +9,7 @@ cd ..
 mkdir -p $1-data/input
 mkdir -p $1-data/output
 
-ffmpeg -i $1 -qscale:v 1 -qmin 1 -vf fps={fps} $1-data/input/%04d.jpg
+ffmpeg -i $1 -qscale:v 1 -qmin 1 -vf fps=5 $1-data/input/%04d.jpg
 
 
 python3.10 convert.py -s $1-data/ --no_gpu

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -9,10 +9,18 @@ cd ..
 mkdir -p $1-data/input
 mkdir -p $1-data/output
 
-ffmpeg -i $1 -qscale:v 1 -qmin 1 -vf fps=5 $1-data/input/%04d.jpg
+FPS="5" #<-change this to change framerate
+
+
+if [ -f $1-data/input/0000.jpg ]
+then
+  echo "File $1 appears to have already been split .."
+else
+  ffmpeg -i $1 -qscale:v 1 -qmin 1 -vf fps=$FPS $1-data/input/%04d.jpg
+fi
 
 
 python3.10 convert.py -s $1-data/ --no_gpu
-python3.10  train.py -s $1-data/ -r 1 --model_path=$1-data/output/
+python3.10 train.py -s $1-data/ -r 1 --model_path=$1-data/output/
 
 exit 0

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR"
+
+
+cd ..
+
+mkdir -p $1-data/input
+mkdir -p $1-data/output
+
+ffmpeg -i $1 -qscale:v 1 -qmin 1 -vf fps={fps} $1-data/input/%04d.jpg
+
+
+python3.10 convert.py -s $1-data/ --no_gpu
+python3.10  train.py -s $1-data/ -r 1 --model_path=$1-data/output/
+
+exit 0

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# This script builds and runs a docker image for local use.
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR"
+cd ..
+REPOSITORY=`pwd`
+
+cd "$DIR"
+
+#https://docs.nvidia.com/ai-enterprise/deployment-guide/dg-docker.html
+sudo apt-get update
+sudo apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo apt-key fingerprint 0EBFCD88
+
+sudo add-apt-repository \
+"deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+$(lsb_release -cs) \
+stable"
+
+
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+
+sudo docker run hello-world
+
+
+#Make sure docker group is ok
+sudo groupadd docker
+sudo usermod -aG docker $USER
+newgrp docker 
+
+exit 0


### PR DESCRIPTION

First of all thanks for providing this amazing work to the Computer Vision Community!

This pull request adds the capability of building a docker container for gaussian-splatting

To install docker with NVIDIA/GPU pass-through support  one can follow the following instructions : 
https://www.howtogeek.com/devops/how-to-use-an-nvidia-gpu-with-docker-containers/


The docker subfolder is added to the project features 5 scripts/items : 


docker/build_and_deploy.sh 
Running this script builds and deploys "gaussian-splatting-container" container. It prepares and installs required libraries, starts and then attaches the container making all the required setup ready for use after issuing just one command!

docker/Dockerfile 
This is the deployed docker file that builds on nvidia/cuda:12.2.0-devel-ubuntu22.04 and creates a docker container with the required system libraries to run the project

docker/initialize.sh
This is a BASH script called internally during container setup to install CERES, colmap and the python dependencies of the project

docker/run.sh
This is a script that automatically processes and then trains on a video file.

Issuing : 
   ./run.sh VIDEOFILE.MOV kickstarts the procedure storing output in VIDEOFILE.MOV-data/output


docker/setup.sh 
Optional script to perform installation of the docker server
