### PR TITLE
2 patches, cuda option to remove asyncrhonous ops, cleanup of network_gui.listener

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -8,7 +8,7 @@
 #
 # For inquiries contact  george.drettakis@inria.fr
 #
-# xvdp removed magick, it is 3x slower than single threaded PIL for resizing
+# xvdp removed magick, even single threaded PIL resizes 4X faster
 
 
 import os
@@ -106,6 +106,6 @@ if args.resize:
         logging.info(f"processing image [{j}/{len(files)}] {source_file}")
         for div in [2,4,8]:
             destination_file = os.path.join(args.source_path, f"images_{div}", file)
-            im.resize([round(i/div) for i in im.size], Image.BICUBIC).save(destination_file)
+            im.resize([round(i/div) for i in im.size], Image.BICUBIC).save(destination_file, quality=100)
 
 print("Done.")

--- a/convert.py
+++ b/convert.py
@@ -8,11 +8,15 @@
 #
 # For inquiries contact  george.drettakis@inria.fr
 #
+# xvdp removed magick, it is 3x slower than single threaded PIL for resizing
+
 
 import os
 import logging
 from argparse import ArgumentParser
 import shutil
+
+from PIL import Image
 
 # This Python script is based on the shell converter script provided in the MipNerF 360 repository.
 parser = ArgumentParser("Colmap converter")
@@ -25,7 +29,7 @@ parser.add_argument("--resize", action="store_true")
 parser.add_argument("--magick_executable", default="", type=str)
 args = parser.parse_args()
 colmap_command = '"{}"'.format(args.colmap_executable) if len(args.colmap_executable) > 0 else "colmap"
-magick_command = '"{}"'.format(args.magick_executable) if len(args.magick_executable) > 0 else "magick"
+
 use_gpu = 1 if not args.no_gpu else 0
 
 if not args.skip_matching:
@@ -87,38 +91,21 @@ for file in files:
     destination_file = os.path.join(args.source_path, "sparse", "0", file)
     shutil.move(source_file, destination_file)
 
-if(args.resize):
+if args.resize:
     print("Copying and resizing...")
 
     # Resize images.
-    os.makedirs(args.source_path + "/images_2", exist_ok=True)
-    os.makedirs(args.source_path + "/images_4", exist_ok=True)
-    os.makedirs(args.source_path + "/images_8", exist_ok=True)
+    for div in [2,4,8]:
+        os.makedirs(args.source_path + f"/images_{div}", exist_ok=True)
     # Get the list of files in the source directory
     files = os.listdir(args.source_path + "/images")
     # Copy each file from the source directory to the destination directory
-    for file in files:
+    for j, file in enumerate(files):
         source_file = os.path.join(args.source_path, "images", file)
-
-        destination_file = os.path.join(args.source_path, "images_2", file)
-        shutil.copy2(source_file, destination_file)
-        exit_code = os.system(magick_command + " mogrify -resize 50% " + destination_file)
-        if exit_code != 0:
-            logging.error(f"50% resize failed with code {exit_code}. Exiting.")
-            exit(exit_code)
-
-        destination_file = os.path.join(args.source_path, "images_4", file)
-        shutil.copy2(source_file, destination_file)
-        exit_code = os.system(magick_command + " mogrify -resize 25% " + destination_file)
-        if exit_code != 0:
-            logging.error(f"25% resize failed with code {exit_code}. Exiting.")
-            exit(exit_code)
-
-        destination_file = os.path.join(args.source_path, "images_8", file)
-        shutil.copy2(source_file, destination_file)
-        exit_code = os.system(magick_command + " mogrify -resize 12.5% " + destination_file)
-        if exit_code != 0:
-            logging.error(f"12.5% resize failed with code {exit_code}. Exiting.")
-            exit(exit_code)
+        im = Image.open(source_file)
+        logging.info(f"processing image [{j}/{len(files)}] {source_file}")
+        for div in [2,4,8]:
+            destination_file = os.path.join(args.source_path, f"images_{div}", file)
+            im.resize([round(i/div) for i in im.size], Image.BICUBIC).save(destination_file)
 
 print("Done.")

--- a/train.py
+++ b/train.py
@@ -48,7 +48,7 @@ def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoi
     ema_loss_for_log = 0.0
     progress_bar = tqdm(range(first_iter, opt.iterations), desc="Training progress")
     first_iter += 1
-    for iteration in range(first_iter, opt.iterations + 1):        
+    for iteration in range(first_iter, opt.iterations + 1):
         if network_gui.conn == None:
             network_gui.try_connect()
         while network_gui.conn != None:
@@ -62,7 +62,10 @@ def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoi
                 if do_training and ((iteration < int(opt.iterations)) or not keep_alive):
                     break
             except Exception as e:
+                network_gui.conn.close()
                 network_gui.conn = None
+                network_gui.listener.close()
+                network_gui.listener = None
 
         iter_start.record()
 
@@ -159,7 +162,7 @@ def training_report(tb_writer, iteration, Ll1, loss, l1_loss, elapsed, testing_i
     # Report test and samples of training set
     if iteration in testing_iterations:
         torch.cuda.empty_cache()
-        validation_configs = ({'name': 'test', 'cameras' : scene.getTestCameras()}, 
+        validation_configs = ({'name': 'test', 'cameras' : scene.getTestCameras()},
                               {'name': 'train', 'cameras' : [scene.getTrainCameras()[idx % len(scene.getTrainCameras())] for idx in range(5, 30, 5)]})
 
         for config in validation_configs:
@@ -202,18 +205,23 @@ if __name__ == "__main__":
     parser.add_argument("--quiet", action="store_true")
     parser.add_argument("--checkpoint_iterations", nargs="+", type=int, default=[])
     parser.add_argument("--start_checkpoint", type=str, default = None)
+    parser.add_argument('--cuda_blocking', action='store_true', default=True)
     args = parser.parse_args(sys.argv[1:])
     args.save_iterations.append(args.iterations)
-    
+
     print("Optimizing " + args.model_path)
 
     # Initialize system state (RNG)
     safe_state(args.quiet)
 
+    # CUDA sometimes fails - option to disable asynchronous operations
+    if args.cuda_blocking:
+        os.environ['CUDA_LAUNCH_BLOCKING'] = "1"
     # Start GUI server, configure and run training
     network_gui.init(args.ip, args.port)
     torch.autograd.set_detect_anomaly(args.detect_anomaly)
-    training(lp.extract(args), op.extract(args), pp.extract(args), args.test_iterations, args.save_iterations, args.checkpoint_iterations, args.start_checkpoint, args.debug_from)
+    training(lp.extract(args), op.extract(args), pp.extract(args), args.test_iterations, args.save_iterations,
+             args.checkpoint_iterations, args.start_checkpoint, args.debug_from)
 
     # All done
     print("\nTraining complete.")


### PR DESCRIPTION
1/ CUDA
In my system running cudatoolkit 11.8 over  NVIDIA-SMI 525.116.04   Driver Version: 525.116.04   CUDA Version: 12.0
I found some errors during training fixable by blocking CUDA asynchronous operations - a bit slower but more robust.
2/ network_gui on interrupted processes listener blocks resources, added linstener.close() and conn.close() on the try except training loop. 

Both these could be fixed better. 
The first would entail debugging why CUDA is barfing on async ops, I dunno.
The second is easier, network_gui could be a class with __enter__ __exit__ that always frees resources.
