### PR TITLE
add GPU number and lazy load img to GPU

### DIFF
--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -52,6 +52,8 @@ class ModelParams(ParamGroup):
         self._images = "images"
         self._resolution = -1
         self._white_background = False
+        self._device_number = 0
+        self._lazy_load = False
         self.data_device = "cuda"
         self.eval = False
         super().__init__(parser, "Loading Parameters", sentinel)

--- a/render.py
+++ b/render.py
@@ -61,6 +61,6 @@ if __name__ == "__main__":
     print("Rendering " + args.model_path)
 
     # Initialize system state (RNG)
-    safe_state(args.quiet)
+    safe_state(args.quiet, args.device_number)
 
     render_sets(model.extract(args), args.iteration, pipeline.extract(args), args.skip_train, args.skip_test)

--- a/scene/cameras.py
+++ b/scene/cameras.py
@@ -17,7 +17,7 @@ from utils.graphics_utils import getWorld2View2, getProjectionMatrix
 class Camera(nn.Module):
     def __init__(self, colmap_id, R, T, FoVx, FoVy, image, gt_alpha_mask,
                  image_name, uid,
-                 trans=np.array([0.0, 0.0, 0.0]), scale=1.0, data_device = "cuda"
+                 trans=np.array([0.0, 0.0, 0.0]), scale=1.0, data_device = "cuda", lazy_load=False
                  ):
         super(Camera, self).__init__()
 
@@ -35,6 +35,9 @@ class Camera(nn.Module):
             print(e)
             print(f"[Warning] Custom device {data_device} failed, fallback to default cuda device" )
             self.data_device = torch.device("cuda")
+
+        if lazy_load:
+            self.data_device = torch.device("cpu")
 
         self.original_image = image.clamp(0.0, 1.0).to(self.data_device)
         self.image_width = self.original_image.shape[2]

--- a/train.py
+++ b/train.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
     print("Optimizing " + args.model_path)
 
     # Initialize system state (RNG)
-    safe_state(args.quiet)
+    safe_state(args.quiet, args.device_number)
 
     # Start GUI server, configure and run training
     network_gui.init(args.ip, args.port)

--- a/utils/camera_utils.py
+++ b/utils/camera_utils.py
@@ -49,7 +49,7 @@ def loadCam(args, id, cam_info, resolution_scale):
     return Camera(colmap_id=cam_info.uid, R=cam_info.R, T=cam_info.T, 
                   FoVx=cam_info.FovX, FoVy=cam_info.FovY, 
                   image=gt_image, gt_alpha_mask=loaded_mask,
-                  image_name=cam_info.image_name, uid=id, data_device=args.data_device)
+                  image_name=cam_info.image_name, uid=id, data_device=args.data_device, lazy_load=args.lazy_load)
 
 def cameraList_from_camInfos(cam_infos, resolution_scale, args):
     camera_list = []

--- a/utils/general_utils.py
+++ b/utils/general_utils.py
@@ -109,7 +109,7 @@ def build_scaling_rotation(s, r):
     L = R @ L
     return L
 
-def safe_state(silent):
+def safe_state(silent, device_number):
     old_f = sys.stdout
     class F:
         def __init__(self, silent):
@@ -130,4 +130,4 @@ def safe_state(silent):
     random.seed(0)
     np.random.seed(0)
     torch.manual_seed(0)
-    torch.cuda.set_device(torch.device("cuda:0"))
+    torch.cuda.set_device(torch.device(f"cuda:{device_number}"))


### PR DESCRIPTION
hello, 
1. I add a gpu number argument in `ModelParams` class.
2. In order to save GPU memory, I cancelled the loading of img to GPU when creating the camera, and delayed loading img to GPU during training. This greatly saves GPU memory. I tested it in RTX2080ti and less than 2GB during initial training, even if trained to 30k, less than 5GB.