### PR TITLE
Assign image tensors to `data_device` immediately on creation.

### DIFF
--- a/utils/camera_utils.py
+++ b/utils/camera_utils.py
@@ -38,7 +38,7 @@ def loadCam(args, id, cam_info, resolution_scale):
         scale = float(global_down) * float(resolution_scale)
         resolution = (int(orig_w / scale), int(orig_h / scale))
 
-    resized_image_rgb = PILtoTorch(cam_info.image, resolution)
+    resized_image_rgb = PILtoTorch(cam_info.image, resolution, args.data_device)
 
     gt_image = resized_image_rgb[:3, ...]
     loaded_mask = None

--- a/utils/general_utils.py
+++ b/utils/general_utils.py
@@ -18,9 +18,9 @@ import random
 def inverse_sigmoid(x):
     return torch.log(x/(1-x))
 
-def PILtoTorch(pil_image, resolution):
+def PILtoTorch(pil_image, resolution, data_device="cuda"):
     resized_image_PIL = pil_image.resize(resolution)
-    resized_image = torch.from_numpy(np.array(resized_image_PIL)) / 255.0
+    resized_image = torch.from_numpy(np.array(resized_image_PIL)).to(data_device) / 255.0
     if len(resized_image.shape) == 3:
         return resized_image.permute(2, 0, 1)
     else:


### PR DESCRIPTION
The tensors which are created from PIL images are first created on the CPU.
https://github.com/graphdeco-inria/gaussian-splatting/blob/d9fad7b3450bf4bd29316315032d57157e23a515/utils/general_utils.py#L23
If `data_device` is "cuda" they are later moved to the GPU. Normally, unreferenced tensors on the CPU should be released but PyTorch doesn't seem to do this. This results in high CPU RAM consumption for the entire training duration even when `data_device` is "cuda". 

Moving the tensors to `data_device` immediately on creation results in a **_dramatic_** decrease in CPU RAM consumption when `data_device` is "cuda".  When training on a T4 instance on Colab with 200 images, CPU RAM consumption went from 10GB down to 2GB. The GPU vRAM consumption doesn't increase as tensors are eventually moved to the GPU anyway.

It might help to move all tensors to `data_device` immediately on creation since PyTorch doesn't seem to deallocate RAM for CPU tensors.