### PR TITLE
Update sorting logic in scene/dataset_readers.py for readColmapSceneInfo

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -143,7 +143,7 @@ def readColmapSceneInfo(path, images, eval, llffhold=8):
 
     reading_dir = "images" if images == None else images
     cam_infos_unsorted = readColmapCameras(cam_extrinsics=cam_extrinsics, cam_intrinsics=cam_intrinsics, images_folder=os.path.join(path, reading_dir))
-    cam_infos = sorted(cam_infos_unsorted.copy(), key = lambda x : x.image_name)
+    cam_infos = sorted(cam_infos_unsorted.copy(), key = lambda x : x.uid)
 
     if eval:
         train_cam_infos = [c for idx, c in enumerate(cam_infos) if idx % llffhold != 0]


### PR DESCRIPTION
Hello,  I found  an issue in [`scene/dataset_readers.py`](https://github.com/graphdeco-inria/gaussian-splatting/blob/main/scene/dataset_readers.py). Specifically, there was a problem with the sorting logic when images were named using numbers, leading to incorrect ordering. The root cause was the original sorting based on the `image_name` attribute, which resulted in unexpected sorting due to the way Python sorts characters. For example, images named as 1.png, 11.png, 2.png, and 22.png were being sorted as 1.png, 11.png, 2.png, and 22.png, respectively.
This PR fixes the issue where images were not sorted correctly when their names contained numbers. The previous sorting based on `image_name` resulted in incorrect order due to the way characters are sorted in Python. By changing the sorting key to `uid`, the images are now sorted accurately and consistently.