### PR TITLE
Fix inconsistent training results with RGBA/PNG images

### DIFF
--- a/utils/general_utils.py
+++ b/utils/general_utils.py
@@ -19,6 +19,21 @@ def inverse_sigmoid(x):
     return torch.log(x/(1-x))
 
 def PILtoTorch(pil_image, resolution):
+    # When resizing RGBA, PIL pre-multiplies the resulting RGB with the resized alpha channel. This gives
+    # different training behaviors depending on whether the image is actually resized (via -r flag) or not.
+    # Moreover, the resized alpha is no longer a perfect binary image due to interpolation, which produces
+    # a significant amount of floaters along the edges. To fix this, we manually mask the RGB if the input
+    # is an RGBA, then we forget the alpha channel entirely. The multiplication of the rendered image with
+    # the alpha_mask during training thus becomes a no-op for RGBA.
+    if pil_image.mode == 'RGBA':
+        from PIL import Image
+        image_np = np.array(pil_image)
+        rgb_np   = image_np[..., :3]
+        alpha_np = image_np[..., 3:]
+        masked_rgb_np = (rgb_np / 255.0) * (alpha_np / 255.0)
+        masked_rgb_np = np.clip(masked_rgb_np, 0.0, 1.0)
+        pil_image = Image.fromarray((masked_rgb_np * 255).astype(np.uint8))
+
     resized_image_PIL = pil_image.resize(resolution)
     resized_image = torch.from_numpy(np.array(resized_image_PIL)) / 255.0
     if len(resized_image.shape) == 3:


### PR DESCRIPTION
## Issue summary
The training relies on PIL to resize the input images and extracts the resized alpha to mask the rendered image during training. Since PIL pre-multiplies the resized RGB with the resized alpha, the training produces different Gaussian points depending on whether the input get resized or not. Moreover, the extracted alpha channel from PIL is not perfectly binarized, causing floaters around the edges. The issue has been going around in #1039, #1121, and #1114 since they trained with either PNG images or a dataset containing masks in the 4th channel (preprocessed DTU, NeRF Synthetic).

The fix is self-contained in the `PILtoTorch` function. It checks if the input is of type RGBA and manually masks the RGB channels. This alpha channel is then discarded and the process continues as if the input was RGB, making the alpha multiplication step in the train script a no-op.

## Details
In the current commit, here's how a ground truth RGBA is treated during the training:
- The loaded image is resized to some resolution with `PIL.Image.Image.resize` in the `PILtoTorch` function.
- The RGB channels of the result are extracted and becomes `gt_image` in `train.py` (via `Camera.original_image`).
- The resized alpha channel is saved separatedly as `alpha_mask`. This mask is then multiplied with the rendered `image` in `train.py` and the loss is called on the `gt_image` and the masked `image`.

If the input RGBA is actually resized in `PILtoTorch` (the `resolution` param is different from the image's resolution), PIL **automatically** multiplies the resized RGB with the resized alpha:
|RGB before `resize`|RGB after `resize`|
|-|-|
|![image](https://github.com/user-attachments/assets/6f83be37-f52a-4ebd-bf91-02d52019c499)|![image](https://github.com/user-attachments/assets/7eec3573-b3e2-44e0-a87b-3fca397ee08f)|

This creates two different scenarios:
- If the image is not resized (no `-r` flag), the RGB ground truth is the original image without masking, and the saved `alpha_mask` is perfectly binarized.
- If the image is resized, the RGB ground truth is masked, but the saved `alpha_mask` is distorted along edges.

### Scenario 1: no resize
The Gaussian points undergoes tension during training since they get masked before getting fed into the loss but the ground truth is the original image:
|GT|Render (Iter 7000)|
|-|-|
|![00030](https://github.com/user-attachments/assets/1658c700-b54e-46ca-84d2-b8820aaaf42f)|![00030](https://github.com/user-attachments/assets/a1ca9fda-8b2d-4ee4-9172-4868919c0a84)|

### Scenario 2: RGBA is resized
The resized `alpha_mask` is not perfectly binarized along the edge due to interpolation. This imperfect mask is multiplied with the rendered image, causing floaters:
|GT|Render `-r 2` (Iter 7000)|
|-|-|
|![00030](https://github.com/user-attachments/assets/7fcd211d-5f79-4bb6-995a-ada894a5a516)|![00030](https://github.com/user-attachments/assets/7d96efda-869b-486b-818f-94eb03438a99)|

### The fix
To minimize the modification, when `PILtoTorch` encounters RGBA, we manually extract and mask the RGB channels and let the input become this new masked RGB. The remaining logic is as-is and the alpha multiplication step in `train.py` becomes no-op.

|Render (Iter 7000)|Render `-r 2` (Iter 7000)|
|-|-|
|![00030](https://github.com/user-attachments/assets/a7c92e67-6dad-405d-9c58-eae2dcada96b)|![00030](https://github.com/user-attachments/assets/1a05f8a6-71db-4407-90bb-f7153c4e2fd9)|

### Test environment
- Python `3.9`
- PyTorch `2.4.0`
- CUDA `12.4`
- MSVC `19.43`

### Notes
 The `render.py` might need fixed to export the masked GT (rather than the original RGB) when running on trained model with original resolution settings (no `- r`).
