### PR TITLE
Fixed the issue that `network_gui` had connection errors when `train_test_exp` was turned on

### DIFF
--- a/gaussian_renderer/__init__.py
+++ b/gaussian_renderer/__init__.py
@@ -110,7 +110,7 @@ def render(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tensor, 
             cov3D_precomp = cov3D_precomp)
         
     # Apply exposure to rendered image (training only)
-    if use_trained_exp:
+    if use_trained_exp and hasattr(viewpoint_camera, 'image_name'):
         exposure = pc.get_exposure_from_name(viewpoint_camera.image_name)
         rendered_image = torch.matmul(rendered_image.permute(1, 2, 0), exposure[:3, :3]).permute(2, 0, 1) + exposure[:3, 3,   None, None]
 


### PR DESCRIPTION
Because `network_gui `using `MiniCam` lacks the properties used when opening train_test_exp, a simple fix for connection errors is performed first