### PR TITLE
Prevent exit codes > 255 in convert.py

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -10,6 +10,7 @@
 #
 
 import os
+import sys
 import logging
 from argparse import ArgumentParser
 import shutil
@@ -27,6 +28,7 @@ args = parser.parse_args()
 colmap_command = '"{}"'.format(args.colmap_executable) if len(args.colmap_executable) > 0 else "colmap"
 magick_command = '"{}"'.format(args.magick_executable) if len(args.magick_executable) > 0 else "magick"
 use_gpu = 1 if not args.no_gpu else 0
+exit = lambda code: sys.exit(code if code <= 255 else 1)
 
 if not args.skip_matching:
     os.makedirs(args.source_path + "/distorted/sparse", exist_ok=True)


### PR DESCRIPTION
The `colmap` executable can return exit codes greater than 255. In the special case of 256, which for example happens on a bad input path

```
E0523 15:37:08.226591     8 logging.cc:56] [option_manager.cc:833] Check failed: ExistsDir(*image_path)
E0523 15:37:08.226668     8 option_manager.cc:899] Invalid options provided.
ERROR:root:Feature extraction failed with code 256. Exiting.
```

this seems to overflow to 0, making scripted tools think the invocation succeeded. Considering behavior of POSIX exit codes that are outside of the range between 0 and 255 [seems to be undefined](https://en.wikipedia.org/wiki/Exit_status#Bash_shell_and_script), it probably makes sense to just exit 1 on anything above 255. The exit code returned by invoking colmap will still be printed for debugging.