### PR TITLE
Fixed direct call of prune_points() issue

### DIFF
--- a/scene/gaussian_model.py
+++ b/scene/gaussian_model.py
@@ -63,6 +63,7 @@ class GaussianModel:
         self.optimizer = None
         self.percent_dense = 0
         self.spatial_lr_scale = 0
+        self.tmp_radii = None
         self.setup_functions()
 
     def capture(self):
@@ -361,7 +362,9 @@ class GaussianModel:
 
         self.denom = self.denom[valid_points_mask]
         self.max_radii2D = self.max_radii2D[valid_points_mask]
-        self.tmp_radii = self.tmp_radii[valid_points_mask]
+        
+        if self.tmp_radii is not None:
+            self.tmp_radii = self.tmp_radii[valid_points_mask]
 
     def cat_tensors_to_optimizer(self, tensors_dict):
         optimizable_tensors = {}


### PR DESCRIPTION
In the original code `self.tmp_radii` is not declared in `self.__init__()`

In train.py when `densify_and_prune()` is called it declares `self.tmp_radii` and sets `self.tmp_radii` to None once densification and pruning is done. 
        
Hence, if `prune_points()` in called it will throw error as attribute does not exist (or) if `densify_and_prune()` was called before it will throw error as we are accessing None.

To rectify this and for better practice
1. Added `self.tmp_radii = None` to `self.__init__()`
2. Added condition to check `if self.temp_radii is not None` before accessing