### PR TITLE
fix: visibility_filter returns wrong type for indexing

### DIFF
--- a/gaussian_renderer/__init__.py
+++ b/gaussian_renderer/__init__.py
@@ -120,7 +120,7 @@ def render(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tensor, 
     out = {
         "render": rendered_image,
         "viewspace_points": screenspace_points,
-        "visibility_filter" : (radii > 0).nonzero(),
+        "visibility_filter" : radii > 0,
         "radii": radii,
         "depth" : depth_image
         }


### PR DESCRIPTION
## Bug

`visibility_filter` in `gaussian_renderer/__init__.py` uses `(radii > 0).nonzero()`, which returns a 2D index tensor of shape `(N, 1)` instead of a boolean mask.

This 2D index tensor causes incorrect advanced indexing behavior when used downstream in `train.py` for operations like:

```python
gaussians.max_radii2D[visibility_filter] = torch.max(gaussians.max_radii2D[visibility_filter], radii[visibility_filter])
```

and in `add_densification_stats`:

```python
self.xyz_gradient_accum[update_filter] += torch.norm(viewspace_point_tensor.grad[update_filter,:2], dim=-1, keepdim=True)
```

These callsites expect a 1D boolean mask for proper element selection, but the 2D index tensor from `.nonzero()` triggers PyTorch advanced indexing, which can produce unexpected shapes and incorrect results.

## Fix

Removed the `.nonzero()` call so `visibility_filter` returns `radii > 0` directly -- a proper 1D boolean mask that works correctly with all downstream indexing operations.