### PR TITLE
Pin cuda-version to match cudatoolkit on Windows

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,8 @@ channels:
   - defaults
 dependencies:
   - cudatoolkit=11.6
+  # Avoid libmamba selecting cuda-version 11.8, which conflicts with cudatoolkit 11.6.
+  - cuda-version=11.6
   - plyfile
   - python=3.7.13
   - pip=22.3.1


### PR DESCRIPTION
## Summary
Pins `cuda-version=11.6` in `environment.yml` to align with the existing `cudatoolkit=11.6` constraint on Windows.

## Why
Conda/libmamba can otherwise select a newer CUDA runtime (e.g. 11.8), which conflicts with `cudatoolkit=11.6` and fails environment solve.

## Scope
- `environment.yml` only
- No training/rendering/runtime code changes