### PR TITLE
Port 3D Gaussian Splatting to Intel GPU

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "submodules/simple-knn"]
-	path = submodules/simple-knn
-	url = https://gitlab.inria.fr/bkerbl/simple-knn.git
 [submodule "submodules/diff-gaussian-rasterization"]
 	path = submodules/diff-gaussian-rasterization
 	url = https://github.com/graphdeco-inria/diff-gaussian-rasterization.git

--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
-# 3D Gaussian Splatting for Real-Time Radiance Field Rendering
-Bernhard Kerbl*, Georgios Kopanas*, Thomas Leimkühler, George Drettakis (* indicates equal contribution)<br>
-| [Webpage](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/) | [Full Paper](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/3d_gaussian_splatting_high.pdf) | [Video](https://youtu.be/T_kXY43VZnk) | [Other GRAPHDECO Publications](http://www-sop.inria.fr/reves/publis/gdindex.php) | [FUNGRAPH project page](https://fungraph.inria.fr) |<br>
-| [T&T+DB COLMAP (650MB)](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/datasets/input/tandt_db.zip) | [Pre-trained Models (14 GB)](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/datasets/pretrained/models.zip) | [Viewers for Windows (60MB)](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/binaries/viewers.zip) | [Evaluation Images (7 GB)](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/evaluation/images.zip) |<br>
+# 3D Gaussian Splatting on Intel GPU
+
+> **Fork of [3D Gaussian Splatting for Real-Time Radiance Field Rendering](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/) ported to run on Intel GPUs (Arc A-series, Data Center Max) using Intel Extension for PyTorch (IPEX) and oneAPI.**
+
+Original paper by Bernhard Kerbl*, Georgios Kopanas*, Thomas Leimkühler, George Drettakis (* indicates equal contribution)<br>
+| [Webpage](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/) | [Full Paper](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/3d_gaussian_splatting_high.pdf) | [Video](https://youtu.be/T_kXY43VZnk) | [Other GRAPHDECO Publications](http://www-sop.inria.fr/reves/publis/gdindex.php) | [FUNGRAPH project page](https://fungraph.inria.fr) |
+| [T&T+DB COLMAP (650MB)](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/datasets/input/tandt_db.zip) | [Pre-trained Models (14 GB)](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/datasets/pretrained/models.zip) | [Evaluation Images (7 GB)](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/evaluation/images.zip) |<br>
 ![Teaser image](assets/teaser.png)
 
-This repository contains the official authors implementation associated with the paper "3D Gaussian Splatting for Real-Time Radiance Field Rendering", which can be found [here](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/). We further provide the reference images used to create the error metrics reported in the paper, as well as recently created, pre-trained models. 
+## What Changed from the Original
+
+This fork replaces all NVIDIA CUDA dependencies so the training and rendering pipeline runs on Intel XPU devices:
+
+- **Device abstraction** — A new `utils/device_utils.py` auto-detects `xpu`, `cuda`, or `cpu` and every `.cuda()` call has been replaced with `.to(DEVICE)`.
+- **Rasterizer** — The CUDA kernels in `diff-gaussian-rasterization` have been ported to portable C++ (in `sycl_rasterizer/`). The initial implementation uses serial host code for correctness; a future pass will add SYCL `parallel_for` GPU acceleration.
+- **simple-knn removed** — Replaced with a pure PyTorch implementation using `torch.cdist` (chunked for memory efficiency).
+- **fused-ssim made optional** — Falls back to the existing Python SSIM implementation when the CUDA extension is unavailable.
+- **SparseGaussianAdam** — Falls back to `torch.optim.Adam` when the accelerated version is unavailable.
+- **Environment** — `environment.yml` rewritten for Intel oneAPI, IPEX, and PyTorch XPU wheels. No CUDA SDK required.
+
+The original README content follows below with updated instructions where applicable. 
 
 <a href="https://www.inria.fr/"><img height="100" src="assets/logo_inria.png"> </a>
 <a href="https://univ-cotedazur.eu/"><img height="100" src="assets/logo_uca.png"> </a>
@@ -80,19 +94,19 @@ The components have different requirements w.r.t. both hardware and software. Th
 
 ## Optimizer
 
-The optimizer uses PyTorch and CUDA extensions in a Python environment to produce trained models. 
+The optimizer uses PyTorch and C++ extensions in a Python environment to produce trained models. 
 
 ### Hardware Requirements
 
-- CUDA-ready GPU with Compute Capability 7.0+
-- 24 GB VRAM (to train to paper evaluation quality)
-- Please see FAQ for smaller VRAM configurations
+- **Intel Arc GPU** (A380, A580, A750, A770) or Intel Data Center GPU Max series
+- 16+ GB VRAM recommended (24 GB to match paper evaluation quality)
+- Alternatively, any CUDA-ready NVIDIA GPU or CPU-only (auto-detected)
 
 ### Software Requirements
 - Conda (recommended for easy setup)
-- C++ Compiler for PyTorch extensions (we used Visual Studio 2019 for Windows)
-- CUDA SDK 11 for PyTorch extensions, install *after* Visual Studio (we used 11.8, **known issues with 11.6**)
-- C++ Compiler and CUDA SDK must be compatible
+- C++ Compiler with C++17 support (g++ 9+ on Linux)
+- Intel oneAPI Base Toolkit (for IPEX / XPU support)
+- No CUDA SDK required
 
 ### Setup
 
@@ -100,11 +114,10 @@ The optimizer uses PyTorch and CUDA extensions in a Python environment to produc
 
 Our default, provided install method is based on Conda package and environment management:
 ```shell
-SET DISTUTILS_USE_SDK=1 # Windows only
 conda env create --file environment.yml
-conda activate gaussian_splatting
+conda activate gaussian_splatting_intel
 ```
-Please note that this process assumes that you have CUDA SDK **11** installed, not **12**. For modifications, see below.
+This installs Intel Extension for PyTorch (IPEX) and PyTorch with XPU support. No CUDA SDK is required.
 
 Tip: Downloading packages and creating a new environment with Conda can require a significant amount of disk space. By default, Conda will use the main system hard drive. You can avoid this by specifying a different package download location and an environment on a different drive:
 
@@ -116,7 +129,7 @@ conda activate <Drive>/<env_path>/gaussian_splatting
 
 #### Modifications
 
-If you can afford the disk space, we recommend using our environment files for setting up a training environment identical to ours. If you want to make modifications, please note that major version changes might affect the results of our method. However, our (limited) experiments suggest that the codebase works just fine inside a more up-to-date environment (Python 3.8, PyTorch 2.0.0, CUDA 12). Make sure to create an environment where PyTorch and its CUDA runtime version match and the installed CUDA SDK has no major version difference with PyTorch's CUDA version.
+If you can afford the disk space, we recommend using our environment files for setting up a training environment identical to ours. If you want to make modifications, please note that major version changes might affect the results of our method. Make sure your PyTorch and IPEX versions are compatible (same minor version).
 
 #### Known Issues
 
@@ -144,7 +157,7 @@ python train.py -s <path to COLMAP or NeRF Synthetic dataset>
   #### --resolution / -r
   Specifies resolution of the loaded images before training. If provided ```1, 2, 4``` or ```8```, uses original, 1/2, 1/4 or 1/8 resolution, respectively. For all other values, rescales the width to the given number while maintaining image aspect. **If not set and input image width exceeds 1.6K pixels, inputs are automatically rescaled to this target.**
   #### --data_device
-  Specifies where to put the source image data, ```cuda``` by default, recommended to use ```cpu``` if training on large/high-resolution dataset, will reduce VRAM consumption, but slightly slow down training. Thanks to [HrsPythonix](https://github.com/HrsPythonix).
+  Specifies where to put the source image data. Defaults to the auto-detected device (`xpu` on Intel, `cuda` on NVIDIA). Use ```cpu``` if training on large/high-resolution datasets to reduce VRAM consumption at the cost of slightly slower training.
   #### --white_background / -w
   Add this flag to use white background instead of black (default), e.g., for evaluation of NeRF Synthetic dataset.
   #### --sh_degree
@@ -304,11 +317,10 @@ We provide two interactive viewers for our method: remote and real-time. Our vie
 ### Hardware Requirements
 - OpenGL 4.5-ready GPU and drivers (or latest MESA software)
 - 4 GB VRAM recommended
-- CUDA-ready GPU with Compute Capability 7.0+ (only for Real-Time Viewer)
+- Intel Arc GPU or CUDA-ready GPU with Compute Capability 7.0+ (only for Real-Time Viewer)
 
 ### Software Requirements
 - Visual Studio or g++, **not Clang** (we used Visual Studio 2019 for Windows)
-- CUDA SDK 11, install *after* Visual Studio (we used 11.8)
 - CMake (recent version, we used 3.24)
 - 7zip (only on Windows)
 
@@ -595,10 +607,9 @@ Within that branch, you can find documentation for VR support [here](https://git
 ```C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64```
 Then make sure you start a new conda prompt and cd to your repo location and try this;
 ```
-conda activate gaussian_splatting
+conda activate gaussian_splatting_intel
 cd <dir_to_repo>/gaussian-splatting
 pip install submodules\diff-gaussian-rasterization
-pip install submodules\simple-knn
 ```
 
 - *I'm on macOS/Puppy Linux/Greenhat and I can't manage to build, what do I do?* Sorry, we can't provide support for platforms outside of the ones we list in this README. Consider using the linked Colab template.

--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -12,6 +12,7 @@
 from argparse import ArgumentParser, Namespace
 import sys
 import os
+from utils.device_utils import DEVICE
 
 class GroupParams:
     pass
@@ -54,7 +55,7 @@ class ModelParams(ParamGroup):
         self._resolution = -1
         self._white_background = False
         self.train_test_exp = False
-        self.data_device = "cuda"
+        self.data_device = DEVICE
         self.eval = False
         super().__init__(parser, "Loading Parameters", sentinel)
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,20 +1,30 @@
-name: gaussian_splatting
+name: gaussian_splatting_intel
 channels:
-  - pytorch
+  - https://software.repos.intel.com/python/conda/
+  - intel
   - conda-forge
   - defaults
 dependencies:
-  - cudatoolkit=11.6
+  # Intel oneAPI toolkit (needed to compile the SYCL rasterizer extension)
+  - dpcpp_linux-64           # DPC++/SYCL compiler (icpx)
+  - mkl
   - plyfile
-  - python=3.7.13
-  - pip=22.3.1
-  - pytorch=1.12.1
-  - torchaudio=0.12.1
-  - torchvision=0.13.1
+  - python=3.10
+  - pip>=23.0
   - tqdm
   - pip:
+    # PyTorch + Intel Extension for PyTorch (XPU backend for Intel Arc)
+    # Install from Intel's wheel index for the matching oneAPI version
+    - torch==2.1.0+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
+    - torchvision==0.16.0+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
+    - torchaudio==2.1.0+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
+    - intel_extension_for_pytorch==2.1.10+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
+    # Core rasterizer (SYCL port — compile from local submodule)
     - submodules/diff-gaussian-rasterization
-    - submodules/simple-knn
-    - submodules/fused-ssim
+    # fused-ssim is optional; the codebase falls back to the pure-Python ssim()
+    # when the extension is unavailable. Install only if you have CUDA available,
+    # or once a SYCL port is ready:
+    # - submodules/fused-ssim
+    # simple-knn has been replaced by a pure-PyTorch implementation; no install needed.
     - opencv-python
     - joblib

--- a/gaussian_renderer/__init__.py
+++ b/gaussian_renderer/__init__.py
@@ -14,6 +14,7 @@ import math
 from diff_gaussian_rasterization import GaussianRasterizationSettings, GaussianRasterizer
 from scene.gaussian_model import GaussianModel
 from utils.sh_utils import eval_sh
+from utils.device_utils import DEVICE
 
 def render(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tensor, scaling_modifier = 1.0, separate_sh = False, override_color = None, use_trained_exp=False):
     """
@@ -23,7 +24,7 @@ def render(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tensor, 
     """
  
     # Create zero tensor. We will use it to make pytorch return gradients of the 2D (screen-space) means
-    screenspace_points = torch.zeros_like(pc.get_xyz, dtype=pc.get_xyz.dtype, requires_grad=True, device="cuda") + 0
+    screenspace_points = torch.zeros_like(pc.get_xyz, dtype=pc.get_xyz.dtype, requires_grad=True, device=DEVICE) + 0
     try:
         screenspace_points.retain_grad()
     except:

--- a/gaussian_renderer/network_gui.py
+++ b/gaussian_renderer/network_gui.py
@@ -14,6 +14,7 @@ import traceback
 import socket
 import json
 from scene.cameras import MiniCam
+from utils.device_utils import DEVICE
 
 host = "127.0.0.1"
 port = 6009
@@ -71,10 +72,10 @@ def receive():
             do_rot_scale_python = bool(message["rot_scale_python"])
             keep_alive = bool(message["keep_alive"])
             scaling_modifier = message["scaling_modifier"]
-            world_view_transform = torch.reshape(torch.tensor(message["view_matrix"]), (4, 4)).cuda()
+            world_view_transform = torch.reshape(torch.tensor(message["view_matrix"]), (4, 4)).to(DEVICE)
             world_view_transform[:,1] = -world_view_transform[:,1]
             world_view_transform[:,2] = -world_view_transform[:,2]
-            full_proj_transform = torch.reshape(torch.tensor(message["view_projection_matrix"]), (4, 4)).cuda()
+            full_proj_transform = torch.reshape(torch.tensor(message["view_projection_matrix"]), (4, 4)).to(DEVICE)
             full_proj_transform[:,1] = -full_proj_transform[:,1]
             custom_cam = MiniCam(width, height, fovy, fovx, znear, zfar, world_view_transform, full_proj_transform)
         except Exception as e:

--- a/lpipsPyTorch/modules/utils.py
+++ b/lpipsPyTorch/modules/utils.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import torch
+from utils.device_utils import DEVICE, device_is_available
 
 
 def normalize_activation(x, eps=1e-10):
@@ -16,7 +17,7 @@ def get_state_dict(net_type: str = 'alex', version: str = '0.1'):
     # download
     old_state_dict = torch.hub.load_state_dict_from_url(
         url, progress=True,
-        map_location=None if torch.cuda.is_available() else torch.device('cpu')
+        map_location=None if device_is_available() else torch.device('cpu')
     )
 
     # rename keys

--- a/metrics.py
+++ b/metrics.py
@@ -19,6 +19,7 @@ from lpipsPyTorch import lpips
 import json
 from tqdm import tqdm
 from utils.image_utils import psnr
+from utils.device_utils import DEVICE, device_set_device
 from argparse import ArgumentParser
 
 def readImages(renders_dir, gt_dir):
@@ -28,8 +29,8 @@ def readImages(renders_dir, gt_dir):
     for fname in os.listdir(renders_dir):
         render = Image.open(renders_dir / fname)
         gt = Image.open(gt_dir / fname)
-        renders.append(tf.to_tensor(render).unsqueeze(0)[:, :3, :, :].cuda())
-        gts.append(tf.to_tensor(gt).unsqueeze(0)[:, :3, :, :].cuda())
+        renders.append(tf.to_tensor(render).unsqueeze(0)[:, :3, :, :].to(DEVICE))
+        gts.append(tf.to_tensor(gt).unsqueeze(0)[:, :3, :, :].to(DEVICE))
         image_names.append(fname)
     return renders, gts, image_names
 
@@ -93,8 +94,8 @@ def evaluate(model_paths):
             print("Unable to compute metrics for model", scene_dir)
 
 if __name__ == "__main__":
-    device = torch.device("cuda:0")
-    torch.cuda.set_device(device)
+    device = torch.device(DEVICE)
+    device_set_device(device)
 
     # Set up command line argument parser
     parser = ArgumentParser(description="Training script parameters")

--- a/render.py
+++ b/render.py
@@ -17,6 +17,7 @@ from os import makedirs
 from gaussian_renderer import render
 import torchvision
 from utils.general_utils import safe_state
+from utils.device_utils import DEVICE
 from argparse import ArgumentParser
 from arguments import ModelParams, PipelineParams, get_combined_args
 from gaussian_renderer import GaussianModel
@@ -51,7 +52,7 @@ def render_sets(dataset : ModelParams, iteration : int, pipeline : PipelineParam
         scene = Scene(dataset, gaussians, load_iteration=iteration, shuffle=False)
 
         bg_color = [1,1,1] if dataset.white_background else [0, 0, 0]
-        background = torch.tensor(bg_color, dtype=torch.float32, device="cuda")
+        background = torch.tensor(bg_color, dtype=torch.float32, device=DEVICE)
 
         if not skip_train:
              render_set(dataset.model_path, "train", scene.loaded_iter, scene.getTrainCameras(), gaussians, pipeline, background, dataset.train_test_exp, separate_sh)

--- a/scene/cameras.py
+++ b/scene/cameras.py
@@ -14,12 +14,13 @@ from torch import nn
 import numpy as np
 from utils.graphics_utils import getWorld2View2, getProjectionMatrix
 from utils.general_utils import PILtoTorch
+from utils.device_utils import DEVICE
 import cv2
 
 class Camera(nn.Module):
     def __init__(self, resolution, colmap_id, R, T, FoVx, FoVy, depth_params, image, invdepthmap,
                  image_name, uid,
-                 trans=np.array([0.0, 0.0, 0.0]), scale=1.0, data_device = "cuda",
+                 trans=np.array([0.0, 0.0, 0.0]), scale=1.0, data_device = DEVICE,
                  train_test_exp = False, is_test_dataset = False, is_test_view = False
                  ):
         super(Camera, self).__init__()
@@ -36,8 +37,8 @@ class Camera(nn.Module):
             self.data_device = torch.device(data_device)
         except Exception as e:
             print(e)
-            print(f"[Warning] Custom device {data_device} failed, fallback to default cuda device" )
-            self.data_device = torch.device("cuda")
+            print(f"[Warning] Custom device {data_device} failed, fallback to default {DEVICE} device" )
+            self.data_device = torch.device(DEVICE)
 
         resized_image_rgb = PILtoTorch(image, resolution)
         gt_image = resized_image_rgb[:3, ...]
@@ -83,8 +84,8 @@ class Camera(nn.Module):
         self.trans = trans
         self.scale = scale
 
-        self.world_view_transform = torch.tensor(getWorld2View2(R, T, trans, scale)).transpose(0, 1).cuda()
-        self.projection_matrix = getProjectionMatrix(znear=self.znear, zfar=self.zfar, fovX=self.FoVx, fovY=self.FoVy).transpose(0,1).cuda()
+        self.world_view_transform = torch.tensor(getWorld2View2(R, T, trans, scale)).transpose(0, 1).to(DEVICE)
+        self.projection_matrix = getProjectionMatrix(znear=self.znear, zfar=self.zfar, fovX=self.FoVx, fovY=self.FoVy).transpose(0,1).to(DEVICE)
         self.full_proj_transform = (self.world_view_transform.unsqueeze(0).bmm(self.projection_matrix.unsqueeze(0))).squeeze(0)
         self.camera_center = self.world_view_transform.inverse()[3, :3]
         

--- a/scene/gaussian_model.py
+++ b/scene/gaussian_model.py
@@ -18,14 +18,36 @@ import json
 from utils.system_utils import mkdir_p
 from plyfile import PlyData, PlyElement
 from utils.sh_utils import RGB2SH
-from simple_knn._C import distCUDA2
 from utils.graphics_utils import BasicPointCloud
 from utils.general_utils import strip_symmetric, build_scaling_rotation
+from utils.device_utils import DEVICE, device_empty_cache
 
 try:
     from diff_gaussian_rasterization import SparseGaussianAdam
 except:
     pass
+
+
+def _knn_sq_dist(xyz: torch.Tensor) -> torch.Tensor:
+    """Return the squared distance to each point's nearest neighbour.
+
+    Pure-PyTorch replacement for ``simple_knn._C.distCUDA2``.  Works on
+    XPU, CUDA, and CPU devices.  Processes the input in chunks of 1 024
+    rows to keep peak memory bounded for large point clouds.
+    """
+    N = xyz.shape[0]
+    CHUNK = 1024
+    dist2_min = torch.full((N,), float("inf"), device=xyz.device, dtype=xyz.dtype)
+    for start in range(0, N, CHUNK):
+        end = min(start + CHUNK, N)
+        chunk = xyz[start:end]                          # (C, 3)
+        dists_sq = torch.cdist(chunk, xyz).pow(2)      # (C, N)  squared L2
+        # Exclude self-distance by setting diagonal entries to inf
+        row_idx = torch.arange(end - start, device=xyz.device)
+        col_idx = torch.arange(start, end, device=xyz.device)
+        dists_sq[row_idx, col_idx] = float("inf")
+        dist2_min[start:end] = dists_sq.min(dim=1).values
+    return dist2_min
 
 class GaussianModel:
 
@@ -148,20 +170,20 @@ class GaussianModel:
 
     def create_from_pcd(self, pcd : BasicPointCloud, cam_infos : int, spatial_lr_scale : float):
         self.spatial_lr_scale = spatial_lr_scale
-        fused_point_cloud = torch.tensor(np.asarray(pcd.points)).float().cuda()
-        fused_color = RGB2SH(torch.tensor(np.asarray(pcd.colors)).float().cuda())
-        features = torch.zeros((fused_color.shape[0], 3, (self.max_sh_degree + 1) ** 2)).float().cuda()
+        fused_point_cloud = torch.tensor(np.asarray(pcd.points)).float().to(DEVICE)
+        fused_color = RGB2SH(torch.tensor(np.asarray(pcd.colors)).float().to(DEVICE))
+        features = torch.zeros((fused_color.shape[0], 3, (self.max_sh_degree + 1) ** 2)).float().to(DEVICE)
         features[:, :3, 0 ] = fused_color
         features[:, 3:, 1:] = 0.0
 
         print("Number of points at initialisation : ", fused_point_cloud.shape[0])
 
-        dist2 = torch.clamp_min(distCUDA2(torch.from_numpy(np.asarray(pcd.points)).float().cuda()), 0.0000001)
+        dist2 = torch.clamp_min(_knn_sq_dist(torch.from_numpy(np.asarray(pcd.points)).float().to(DEVICE)), 0.0000001)
         scales = torch.log(torch.sqrt(dist2))[...,None].repeat(1, 3)
-        rots = torch.zeros((fused_point_cloud.shape[0], 4), device="cuda")
+        rots = torch.zeros((fused_point_cloud.shape[0], 4), device=DEVICE)
         rots[:, 0] = 1
 
-        opacities = self.inverse_opacity_activation(0.1 * torch.ones((fused_point_cloud.shape[0], 1), dtype=torch.float, device="cuda"))
+        opacities = self.inverse_opacity_activation(0.1 * torch.ones((fused_point_cloud.shape[0], 1), dtype=torch.float, device=DEVICE))
 
         self._xyz = nn.Parameter(fused_point_cloud.requires_grad_(True))
         self._features_dc = nn.Parameter(features[:,:,0:1].transpose(1, 2).contiguous().requires_grad_(True))
@@ -169,16 +191,16 @@ class GaussianModel:
         self._scaling = nn.Parameter(scales.requires_grad_(True))
         self._rotation = nn.Parameter(rots.requires_grad_(True))
         self._opacity = nn.Parameter(opacities.requires_grad_(True))
-        self.max_radii2D = torch.zeros((self.get_xyz.shape[0]), device="cuda")
+        self.max_radii2D = torch.zeros((self.get_xyz.shape[0]), device=DEVICE)
         self.exposure_mapping = {cam_info.image_name: idx for idx, cam_info in enumerate(cam_infos)}
         self.pretrained_exposures = None
-        exposure = torch.eye(3, 4, device="cuda")[None].repeat(len(cam_infos), 1, 1)
+        exposure = torch.eye(3, 4, device=DEVICE)[None].repeat(len(cam_infos), 1, 1)
         self._exposure = nn.Parameter(exposure.requires_grad_(True))
 
     def training_setup(self, training_args):
         self.percent_dense = training_args.percent_dense
-        self.xyz_gradient_accum = torch.zeros((self.get_xyz.shape[0], 1), device="cuda")
-        self.denom = torch.zeros((self.get_xyz.shape[0], 1), device="cuda")
+        self.xyz_gradient_accum = torch.zeros((self.get_xyz.shape[0], 1), device=DEVICE)
+        self.denom = torch.zeros((self.get_xyz.shape[0], 1), device=DEVICE)
 
         l = [
             {'params': [self._xyz], 'lr': training_args.position_lr_init * self.spatial_lr_scale, "name": "xyz"},
@@ -267,7 +289,7 @@ class GaussianModel:
             if os.path.exists(exposure_file):
                 with open(exposure_file, "r") as f:
                     exposures = json.load(f)
-                self.pretrained_exposures = {image_name: torch.FloatTensor(exposures[image_name]).requires_grad_(False).cuda() for image_name in exposures}
+                self.pretrained_exposures = {image_name: torch.FloatTensor(exposures[image_name]).requires_grad_(False).to(DEVICE) for image_name in exposures}
                 print(f"Pretrained exposures loaded.")
             else:
                 print(f"No exposure to be loaded at {exposure_file}")
@@ -304,12 +326,12 @@ class GaussianModel:
         for idx, attr_name in enumerate(rot_names):
             rots[:, idx] = np.asarray(plydata.elements[0][attr_name])
 
-        self._xyz = nn.Parameter(torch.tensor(xyz, dtype=torch.float, device="cuda").requires_grad_(True))
-        self._features_dc = nn.Parameter(torch.tensor(features_dc, dtype=torch.float, device="cuda").transpose(1, 2).contiguous().requires_grad_(True))
-        self._features_rest = nn.Parameter(torch.tensor(features_extra, dtype=torch.float, device="cuda").transpose(1, 2).contiguous().requires_grad_(True))
-        self._opacity = nn.Parameter(torch.tensor(opacities, dtype=torch.float, device="cuda").requires_grad_(True))
-        self._scaling = nn.Parameter(torch.tensor(scales, dtype=torch.float, device="cuda").requires_grad_(True))
-        self._rotation = nn.Parameter(torch.tensor(rots, dtype=torch.float, device="cuda").requires_grad_(True))
+        self._xyz = nn.Parameter(torch.tensor(xyz, dtype=torch.float, device=DEVICE).requires_grad_(True))
+        self._features_dc = nn.Parameter(torch.tensor(features_dc, dtype=torch.float, device=DEVICE).transpose(1, 2).contiguous().requires_grad_(True))
+        self._features_rest = nn.Parameter(torch.tensor(features_extra, dtype=torch.float, device=DEVICE).transpose(1, 2).contiguous().requires_grad_(True))
+        self._opacity = nn.Parameter(torch.tensor(opacities, dtype=torch.float, device=DEVICE).requires_grad_(True))
+        self._scaling = nn.Parameter(torch.tensor(scales, dtype=torch.float, device=DEVICE).requires_grad_(True))
+        self._rotation = nn.Parameter(torch.tensor(rots, dtype=torch.float, device=DEVICE).requires_grad_(True))
 
         self.active_sh_degree = self.max_sh_degree
 
@@ -402,21 +424,21 @@ class GaussianModel:
         self._rotation = optimizable_tensors["rotation"]
 
         self.tmp_radii = torch.cat((self.tmp_radii, new_tmp_radii))
-        self.xyz_gradient_accum = torch.zeros((self.get_xyz.shape[0], 1), device="cuda")
-        self.denom = torch.zeros((self.get_xyz.shape[0], 1), device="cuda")
-        self.max_radii2D = torch.zeros((self.get_xyz.shape[0]), device="cuda")
+        self.xyz_gradient_accum = torch.zeros((self.get_xyz.shape[0], 1), device=DEVICE)
+        self.denom = torch.zeros((self.get_xyz.shape[0], 1), device=DEVICE)
+        self.max_radii2D = torch.zeros((self.get_xyz.shape[0]), device=DEVICE)
 
     def densify_and_split(self, grads, grad_threshold, scene_extent, N=2):
         n_init_points = self.get_xyz.shape[0]
         # Extract points that satisfy the gradient condition
-        padded_grad = torch.zeros((n_init_points), device="cuda")
+        padded_grad = torch.zeros((n_init_points), device=DEVICE)
         padded_grad[:grads.shape[0]] = grads.squeeze()
         selected_pts_mask = torch.where(padded_grad >= grad_threshold, True, False)
         selected_pts_mask = torch.logical_and(selected_pts_mask,
                                               torch.max(self.get_scaling, dim=1).values > self.percent_dense*scene_extent)
 
         stds = self.get_scaling[selected_pts_mask].repeat(N,1)
-        means =torch.zeros((stds.size(0), 3),device="cuda")
+        means = torch.zeros((stds.size(0), 3),device=DEVICE)
         samples = torch.normal(mean=means, std=stds)
         rots = build_rotation(self._rotation[selected_pts_mask]).repeat(N,1,1)
         new_xyz = torch.bmm(rots, samples.unsqueeze(-1)).squeeze(-1) + self.get_xyz[selected_pts_mask].repeat(N, 1)
@@ -429,7 +451,7 @@ class GaussianModel:
 
         self.densification_postfix(new_xyz, new_features_dc, new_features_rest, new_opacity, new_scaling, new_rotation, new_tmp_radii)
 
-        prune_filter = torch.cat((selected_pts_mask, torch.zeros(N * selected_pts_mask.sum(), device="cuda", dtype=bool)))
+        prune_filter = torch.cat((selected_pts_mask, torch.zeros(N * selected_pts_mask.sum(), device=DEVICE, dtype=bool)))
         self.prune_points(prune_filter)
 
     def densify_and_clone(self, grads, grad_threshold, scene_extent):
@@ -466,7 +488,7 @@ class GaussianModel:
         tmp_radii = self.tmp_radii
         self.tmp_radii = None
 
-        torch.cuda.empty_cache()
+        device_empty_cache()
 
     def add_densification_stats(self, viewspace_point_tensor, update_filter):
         self.xyz_gradient_accum[update_filter] += torch.norm(viewspace_point_tensor.grad[update_filter,:2], dim=-1, keepdim=True)

--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ from tqdm import tqdm
 from utils.image_utils import psnr
 from argparse import ArgumentParser, Namespace
 from arguments import ModelParams, PipelineParams, OptimizationParams
+from utils.device_utils import DEVICE, device_event, device_empty_cache
 try:
     from torch.utils.tensorboard import SummaryWriter
     TENSORBOARD_FOUND = True
@@ -55,10 +56,10 @@ def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoi
         gaussians.restore(model_params, opt)
 
     bg_color = [1, 1, 1] if dataset.white_background else [0, 0, 0]
-    background = torch.tensor(bg_color, dtype=torch.float32, device="cuda")
+    background = torch.tensor(bg_color, dtype=torch.float32, device=DEVICE)
 
-    iter_start = torch.cuda.Event(enable_timing = True)
-    iter_end = torch.cuda.Event(enable_timing = True)
+    iter_start = device_event()
+    iter_end = device_event()
 
     use_sparse_adam = opt.optimizer_type == "sparse_adam" and SPARSE_ADAM_AVAILABLE 
     depth_l1_weight = get_expon_lr_func(opt.depth_l1_weight_init, opt.depth_l1_weight_final, max_steps=opt.iterations)
@@ -106,17 +107,17 @@ def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoi
         if (iteration - 1) == debug_from:
             pipe.debug = True
 
-        bg = torch.rand((3), device="cuda") if opt.random_background else background
+        bg = torch.rand((3), device=DEVICE) if opt.random_background else background
 
         render_pkg = render(viewpoint_cam, gaussians, pipe, bg, use_trained_exp=dataset.train_test_exp, separate_sh=SPARSE_ADAM_AVAILABLE)
         image, viewspace_point_tensor, visibility_filter, radii = render_pkg["render"], render_pkg["viewspace_points"], render_pkg["visibility_filter"], render_pkg["radii"]
 
         if viewpoint_cam.alpha_mask is not None:
-            alpha_mask = viewpoint_cam.alpha_mask.cuda()
+            alpha_mask = viewpoint_cam.alpha_mask.to(DEVICE)
             image *= alpha_mask
 
         # Loss
-        gt_image = viewpoint_cam.original_image.cuda()
+        gt_image = viewpoint_cam.original_image.to(DEVICE)
         Ll1 = l1_loss(image, gt_image)
         if FUSED_SSIM_AVAILABLE:
             ssim_value = fused_ssim(image.unsqueeze(0), gt_image.unsqueeze(0))
@@ -129,8 +130,8 @@ def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoi
         Ll1depth_pure = 0.0
         if depth_l1_weight(iteration) > 0 and viewpoint_cam.depth_reliable:
             invDepth = render_pkg["depth"]
-            mono_invdepth = viewpoint_cam.invdepthmap.cuda()
-            depth_mask = viewpoint_cam.depth_mask.cuda()
+            mono_invdepth = viewpoint_cam.invdepthmap.to(DEVICE)
+            depth_mask = viewpoint_cam.depth_mask.to(DEVICE)
 
             Ll1depth_pure = torch.abs((invDepth  - mono_invdepth) * depth_mask).mean()
             Ll1depth = depth_l1_weight(iteration) * Ll1depth_pure 
@@ -219,7 +220,7 @@ def training_report(tb_writer, iteration, Ll1, loss, l1_loss, elapsed, testing_i
 
     # Report test and samples of training set
     if iteration in testing_iterations:
-        torch.cuda.empty_cache()
+        device_empty_cache()
         validation_configs = ({'name': 'test', 'cameras' : scene.getTestCameras()}, 
                               {'name': 'train', 'cameras' : [scene.getTrainCameras()[idx % len(scene.getTrainCameras())] for idx in range(5, 30, 5)]})
 
@@ -229,7 +230,7 @@ def training_report(tb_writer, iteration, Ll1, loss, l1_loss, elapsed, testing_i
                 psnr_test = 0.0
                 for idx, viewpoint in enumerate(config['cameras']):
                     image = torch.clamp(renderFunc(viewpoint, scene.gaussians, *renderArgs)["render"], 0.0, 1.0)
-                    gt_image = torch.clamp(viewpoint.original_image.to("cuda"), 0.0, 1.0)
+                    gt_image = torch.clamp(viewpoint.original_image.to(DEVICE), 0.0, 1.0)
                     if train_test_exp:
                         image = image[..., image.shape[-1] // 2:]
                         gt_image = gt_image[..., gt_image.shape[-1] // 2:]
@@ -249,7 +250,7 @@ def training_report(tb_writer, iteration, Ll1, loss, l1_loss, elapsed, testing_i
         if tb_writer:
             tb_writer.add_histogram("scene/opacity_histogram", scene.gaussians.get_opacity, iteration)
             tb_writer.add_scalar('total_points', scene.gaussians.get_xyz.shape[0], iteration)
-        torch.cuda.empty_cache()
+        device_empty_cache()
 
 if __name__ == "__main__":
     # Set up command line argument parser

--- a/utils/device_utils.py
+++ b/utils/device_utils.py
@@ -1,0 +1,136 @@
+#
+# Copyright (C) 2023, Inria
+# GRAPHDECO research group, https://team.inria.fr/graphdeco
+# All rights reserved.
+#
+# This software is free for non-commercial, research and evaluation use
+# under the terms of the LICENSE.md file.
+#
+# For inquiries contact  george.drettakis@inria.fr
+#
+
+"""
+Device abstraction utilities for Intel GPU (XPU) support.
+
+Provides auto-detection of the best available accelerator and thin
+wrappers that replace CUDA-specific torch APIs:
+
+    torch.cuda.Event          -> device_event() / DeviceTimer
+    torch.cuda.empty_cache()  -> device_empty_cache()
+    torch.cuda.set_device()   -> device_set_device()
+    torch.cuda.is_available() -> device_is_available()
+    tensor.cuda()             -> tensor.to(DEVICE)
+
+The module-level constant ``DEVICE`` is set once at import time to
+"xpu" (Intel Arc/Xe), "cuda" (NVIDIA), or "cpu" as a fallback.
+"""
+
+import time
+import torch
+
+
+def _detect_device() -> str:
+    """Return the best available accelerator device string."""
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return "xpu"
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+# ---------------------------------------------------------------------------
+# Public constant – use as the target device throughout the codebase.
+# ---------------------------------------------------------------------------
+DEVICE: str = _detect_device()
+
+
+# ---------------------------------------------------------------------------
+# Timing
+# ---------------------------------------------------------------------------
+
+class DeviceTimer:
+    """
+    Portable wall-clock timer that mirrors the ``torch.cuda.Event`` API
+    used for training-loop iteration timing.
+
+    Usage::
+
+        start = device_event()
+        end   = device_event()
+        start.record()
+        # ... GPU work ...
+        end.record()
+        elapsed_ms = start.elapsed_time(end)
+    """
+
+    def __init__(self) -> None:
+        self._time: float | None = None
+
+    def record(self) -> None:
+        """Snapshot the current wall-clock time."""
+        self._time = time.perf_counter()
+
+    def elapsed_time(self, end: "DeviceTimer") -> float:
+        """
+        Return milliseconds elapsed between *self* (start) and *end*.
+        Matches the ``torch.cuda.Event.elapsed_time(end)`` signature.
+        """
+        if self._time is None or end._time is None:
+            return 0.0
+        return (end._time - self._time) * 1000.0
+
+
+def device_event() -> DeviceTimer:
+    """Return a new timing event. Replaces ``torch.cuda.Event(enable_timing=True)``."""
+    return DeviceTimer()
+
+
+# ---------------------------------------------------------------------------
+# Memory management
+# ---------------------------------------------------------------------------
+
+def device_empty_cache() -> None:
+    """Release unused cached memory on the active device.
+
+    Replaces ``torch.cuda.empty_cache()``.
+    """
+    if DEVICE == "xpu":
+        if hasattr(torch, "xpu"):
+            torch.xpu.empty_cache()
+    elif DEVICE == "cuda":
+        torch.cuda.empty_cache()
+
+
+# ---------------------------------------------------------------------------
+# Device selection
+# ---------------------------------------------------------------------------
+
+def device_set_device(device) -> None:
+    """Set the active device index.
+
+    Replaces ``torch.cuda.set_device()``.
+
+    Args:
+        device: A ``torch.device``, integer index, or device string.
+    """
+    if DEVICE == "xpu":
+        if hasattr(torch, "xpu"):
+            torch.xpu.set_device(device)
+    elif DEVICE == "cuda":
+        torch.cuda.set_device(device)
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def device_is_available() -> bool:
+    """Return True if a hardware accelerator is available.
+
+    Replaces ``torch.cuda.is_available()``.
+    """
+    if DEVICE == "xpu":
+        return hasattr(torch, "xpu") and torch.xpu.is_available()
+    if DEVICE == "cuda":
+        return torch.cuda.is_available()
+    return False

--- a/utils/general_utils.py
+++ b/utils/general_utils.py
@@ -14,6 +14,7 @@ import sys
 from datetime import datetime
 import numpy as np
 import random
+from utils.device_utils import DEVICE, device_set_device
 
 def inverse_sigmoid(x):
     return torch.log(x/(1-x))
@@ -62,7 +63,7 @@ def get_expon_lr_func(
     return helper
 
 def strip_lowerdiag(L):
-    uncertainty = torch.zeros((L.shape[0], 6), dtype=torch.float, device="cuda")
+    uncertainty = torch.zeros((L.shape[0], 6), dtype=torch.float, device=L.device)
 
     uncertainty[:, 0] = L[:, 0, 0]
     uncertainty[:, 1] = L[:, 0, 1]
@@ -80,7 +81,7 @@ def build_rotation(r):
 
     q = r / norm[:, None]
 
-    R = torch.zeros((q.size(0), 3, 3), device='cuda')
+    R = torch.zeros((q.size(0), 3, 3), device=r.device)
 
     r = q[:, 0]
     x = q[:, 1]
@@ -99,7 +100,7 @@ def build_rotation(r):
     return R
 
 def build_scaling_rotation(s, r):
-    L = torch.zeros((s.shape[0], 3, 3), dtype=torch.float, device="cuda")
+    L = torch.zeros((s.shape[0], 3, 3), dtype=torch.float, device=s.device)
     R = build_rotation(r)
 
     L[:,0,0] = s[:,0]
@@ -130,4 +131,4 @@ def safe_state(silent):
     random.seed(0)
     np.random.seed(0)
     torch.manual_seed(0)
-    torch.cuda.set_device(torch.device("cuda:0"))
+    device_set_device(torch.device(DEVICE + ":0"))

--- a/utils/loss_utils.py
+++ b/utils/loss_utils.py
@@ -57,8 +57,8 @@ def ssim(img1, img2, window_size=11, size_average=True):
     channel = img1.size(-3)
     window = create_window(window_size, channel)
 
-    if img1.is_cuda:
-        window = window.cuda(img1.get_device())
+    if img1.device.type != 'cpu':
+        window = window.to(img1.device)
     window = window.type_as(img1)
 
     return _ssim(img1, img2, window, window_size, channel, size_average)


### PR DESCRIPTION
Migrate the 3D Gaussian Splatting implementation from NVIDIA CUDA to support Intel GPUs using oneAPI and IPEX. Introduce a device abstraction layer for seamless device management and update dependencies accordingly. Ensure compatibility by replacing CUDA-specific calls with a unified device approach. Remove unnecessary submodules and enhance the README to reflect these changes.