### PR TITLE
Fix np.byte dtype in dataset_readers.py — breaks PIL with NumPy 2.x

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -256,7 +256,7 @@ def readCamerasFromTransforms(path, transformsfile, depths_folder, white_backgro
 
             norm_data = im_data / 255.0
             arr = norm_data[:,:,:3] * norm_data[:, :, 3:4] + bg * (1 - norm_data[:, :, 3:4])
-            image = Image.fromarray(np.array(arr*255.0, dtype=np.byte), "RGB")
+            image = Image.fromarray(np.array(arr*255.0, dtype=np.uint8), "RGB")
 
             fovy = focal2fov(fov2focal(fovx, image.size[0]), image.size[1])
             FovY = fovy 


### PR DESCRIPTION
## Problem

`scene/dataset_readers.py` uses `dtype=np.byte` when constructing an RGB image array:

```python
image = Image.fromarray(np.array(arr*255.0, dtype=np.byte), "RGB")
```

`np.byte` is a **signed int8** type. `Image.fromarray()` expects **unsigned uint8** for RGB images. This raises:

```
TypeError: Cannot handle this data type: (1, 1, 3), |i1
```

This error surfaces on **NumPy 2.x**, which enforces stricter dtype checking. On NumPy 1.x the signed type was silently accepted but still technically incorrect (values above 127 would overflow to negative).

## Fix

```python
image = Image.fromarray(np.array(arr*255.0, dtype=np.uint8), "RGB")
```

One character change: `np.byte` → `np.uint8`.

## Impact

Affects anyone loading **Blender synthetic (NeRF format)** datasets (`readNerfSyntheticInfo`) with images that have an alpha channel, when using NumPy 2.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)