### PR TITLE
bug : Update gaussian_model.py 154-155 lines

### DIFF
--- a/scene/gaussian_model.py
+++ b/scene/gaussian_model.py
@@ -151,8 +151,8 @@ class GaussianModel:
         fused_point_cloud = torch.tensor(np.asarray(pcd.points)).float().cuda()
         fused_color = RGB2SH(torch.tensor(np.asarray(pcd.colors)).float().cuda())
         features = torch.zeros((fused_color.shape[0], 3, (self.max_sh_degree + 1) ** 2)).float().cuda()
-        features[:, :3, 0 ] = fused_color
-        features[:, 3:, 1:] = 0.0
+        features[:, :, 0 ] = fused_color
+        features[:, :, 1:] = 0.0
 
         print("Number of points at initialisation : ", fused_point_cloud.shape[0])
 


### PR DESCRIPTION
Description : During code study, I found a minor issue in the create_from_pcd function when initializing SH features 
Current code: 
```
features = torch.zeros((fused_color.shape[0], 3, (self.max_sh_degree + 1) ** 2)).float().cuda()
features[:, :3, 0] = fused_color
features[:, 3:, 1:] = 0.0
```
Problem： 
    The second dimension of features is exactly 3 (RGB channels), so :3 is redundant
    features[:, 3:, 1:] will produce an empty slice since dimension 1 only has indices 0,1,2

Proposed fix：
```
features = torch.zeros((fused_color.shape[0], 3, (self.max_sh_degree + 1) ** 2)).float().cuda()
features[:, :, 0] = fused_color
features[:, :, 1:] = 0.0
```
This sets the DC component (index 0) for all RGB channels to the initial color, and zeros out all higher-order SH coefficients. The functionality remains identical, but the code is cleaner and avoids unnecessary slicing.

Impact: No functional change, just code clarity improvement。
